### PR TITLE
Feature: Table support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@
 
 language: php
 
+sudo: false
+
 php:
   - 5.4
   - 5.5
@@ -14,7 +16,7 @@ matrix:
     - php: nightly
 
 before_script:
-  - wget 'https://github.com/xp-framework/xp-runners/releases/download/v5.2.0/setup' -O - | php
+  - wget 'https://github.com/xp-framework/xp-runners/releases/download/v5.5.0/setup' -O - | php
   - composer install --prefer-dist
   - echo "vendor/autoload.php" > composer.pth
   - echo "use=vendor/xp-framework/core" > xp.ini

--- a/src/main/php/net/daringfireball/markdown/Cell.class.php
+++ b/src/main/php/net/daringfireball/markdown/Cell.class.php
@@ -1,9 +1,16 @@
 <?php namespace net\daringfireball\markdown;
 
-class Row extends NodeList {
+class Cell extends NodeList {
+  private $type;
 
-  /** @return var[][] */
-  public function cells() { return $this->nodes; }
+  /**
+   * Creates a new list
+   *
+   * @param  string $type either "th" or "td"
+   */
+  public function __construct($type) {
+    $this->type= $type;
+  }
 
   /**
    * Emit this table row
@@ -16,6 +23,6 @@ class Row extends NodeList {
     foreach ($this->nodes as $cell) {
       $r.= $cell->emit($definitions);
     }
-    return '<tr>'.$r.'</tr>';
+    return '<'.$this->type.'>'.$r.'</'.$this->type.'>';
   }
 }

--- a/src/main/php/net/daringfireball/markdown/Cell.class.php
+++ b/src/main/php/net/daringfireball/markdown/Cell.class.php
@@ -1,15 +1,17 @@
 <?php namespace net\daringfireball\markdown;
 
 class Cell extends NodeList {
-  private $type;
+  private $type, $alignment;
 
   /**
    * Creates a new list
    *
    * @param  string $type either "th" or "td"
+   * @param  string $alignment
    */
-  public function __construct($type) {
+  public function __construct($type, $alignment) {
     $this->type= $type;
+    $this->alignment= $alignment;
   }
 
   /**
@@ -23,6 +25,7 @@ class Cell extends NodeList {
     foreach ($this->nodes as $cell) {
       $r.= $cell->emit($definitions);
     }
-    return '<'.$this->type.'>'.$r.'</'.$this->type.'>';
+    $attr= $this->alignment ? ' style="text-align: '.$this->alignment.'"' : '';
+    return '<'.$this->type.$attr.'>'.$r.'</'.$this->type.'>';
   }
 }

--- a/src/main/php/net/daringfireball/markdown/CodeBlock.class.php
+++ b/src/main/php/net/daringfireball/markdown/CodeBlock.class.php
@@ -19,7 +19,7 @@ class CodeBlock extends NodeList {
   public function code() {
     $r= '';
     foreach ($this->nodes as $node) {
-      $r.= "\n".cast($node, Text::class)->value;
+      $r.= "\n".cast($node, 'net.daringfireball.markdown.Text')->value;
     }
     return substr($r, 1);
   }

--- a/src/main/php/net/daringfireball/markdown/InlineTableContext.class.php
+++ b/src/main/php/net/daringfireball/markdown/InlineTableContext.class.php
@@ -1,0 +1,18 @@
+<?php namespace net\daringfireball\markdown;
+
+class InlineTableContext extends TableContext {
+
+  /**
+   * Parse a line into a cells
+   *
+   * @param  string $line
+   * @return string[]
+   */
+  protected function cellsIn($line) {
+    if (preg_match('/^(.+\|.+)+$/', $line)) {
+      return explode('|', $line);
+    } else {
+      return null;
+    }
+  }
+}

--- a/src/main/php/net/daringfireball/markdown/Markdown.class.php
+++ b/src/main/php/net/daringfireball/markdown/Markdown.class.php
@@ -171,13 +171,23 @@ class Markdown extends \lang\Object {
     });
     $this->addHandler('/^\|.+\| *$/', function($lines, $matches, $result, $ctx) {
       $separator= $lines->nextLine();
-      $result->append($ctx->enter(new WrappedTableContext($matches[0], $separator))->parse($lines));
-      return true;
+      if (preg_match('/^\|[ :|-]+\| *$/', $separator)) {
+        $result->append($ctx->enter(new WrappedTableContext($matches[0], $separator))->parse($lines));
+        return true;
+      } else {
+        $lines->resetLine($separator);
+        return false;
+      }
     });
     $this->addHandler('/^(.+\|.+)+$/', function($lines, $matches, $result, $ctx) {
       $separator= $lines->nextLine();
-      $result->append($ctx->enter(new InlineTableContext($matches[0], $separator))->parse($lines));
-      return true;
+      if (preg_match('/^([ :|-]+\|[ :|-]+)+$/', $separator)) {
+        $result->append($ctx->enter(new InlineTableContext($matches[0], $separator))->parse($lines));
+        return true;
+      } else {
+        $lines->resetLine($separator);
+        return false;
+      }
     });
   }
 

--- a/src/main/php/net/daringfireball/markdown/Markdown.class.php
+++ b/src/main/php/net/daringfireball/markdown/Markdown.class.php
@@ -170,8 +170,7 @@ class Markdown extends \lang\Object {
       return true;
     });
     $this->addHandler('/^\|.+\|$/', function($lines, $matches, $result, $ctx) {
-      $lines->resetLine($matches[0]);
-      $result->append($ctx->enter(new TableContext())->parse($lines));
+      $result->append($ctx->enter(new TableContext($matches[0], $lines->nextLine()))->parse($lines));
       return true;
     });
   }

--- a/src/main/php/net/daringfireball/markdown/Markdown.class.php
+++ b/src/main/php/net/daringfireball/markdown/Markdown.class.php
@@ -169,6 +169,11 @@ class Markdown extends \lang\Object {
       $result->append($ctx->enter(new FencedCodeContext($matches[1]))->parse($lines));
       return true;
     });
+    $this->addHandler('/^\|.+\|$/', function($lines, $matches, $result, $ctx) {
+      $lines->resetLine($matches[0]);
+      $result->append($ctx->enter(new TableContext())->parse($lines));
+      return true;
+    });
   }
 
   /**

--- a/src/main/php/net/daringfireball/markdown/Markdown.class.php
+++ b/src/main/php/net/daringfireball/markdown/Markdown.class.php
@@ -169,8 +169,14 @@ class Markdown extends \lang\Object {
       $result->append($ctx->enter(new FencedCodeContext($matches[1]))->parse($lines));
       return true;
     });
-    $this->addHandler('/^\|.+\|$/', function($lines, $matches, $result, $ctx) {
-      $result->append($ctx->enter(new TableContext($matches[0], $lines->nextLine()))->parse($lines));
+    $this->addHandler('/^\|.+\| *$/', function($lines, $matches, $result, $ctx) {
+      $separator= $lines->nextLine();
+      $result->append($ctx->enter(new WrappedTableContext($matches[0], $separator))->parse($lines));
+      return true;
+    });
+    $this->addHandler('/^(.+\|.+)+$/', function($lines, $matches, $result, $ctx) {
+      $separator= $lines->nextLine();
+      $result->append($ctx->enter(new InlineTableContext($matches[0], $separator))->parse($lines));
       return true;
     });
   }

--- a/src/main/php/net/daringfireball/markdown/Row.class.php
+++ b/src/main/php/net/daringfireball/markdown/Row.class.php
@@ -1,0 +1,28 @@
+<?php namespace net\daringfireball\markdown;
+
+class Row extends NodeList {
+  private $type;
+
+  /**
+   * Creates a new list
+   *
+   * @param  string $type either "th" or "td"
+   */
+  public function __construct($type) {
+    $this->type= $type;
+  }
+
+  /**
+   * Emit this table row
+   *
+   * @param  [:net.daringfireball.markdown.Link] $definitions
+   * @return string
+   */
+  public function emit($definitions) {
+    $r= '';
+    foreach ($this->nodes as $cell) {
+      $r.= '<'.$this->type.'>'.$cell->emit($definitions).'</'.$this->type.'>';
+    }
+    return '<tr>'.$r.'</tr>';
+  }
+}

--- a/src/main/php/net/daringfireball/markdown/Table.class.php
+++ b/src/main/php/net/daringfireball/markdown/Table.class.php
@@ -1,5 +1,11 @@
 <?php namespace net\daringfireball\markdown;
 
+/**
+ * A table in markdown
+ *
+ * @see   http://www.tablesgenerator.com/markdown_tables
+ * @test  xp://net.daringfireball.markdown.unittest.TableTest
+ */
 class Table extends NodeList {
  
   /**

--- a/src/main/php/net/daringfireball/markdown/Table.class.php
+++ b/src/main/php/net/daringfireball/markdown/Table.class.php
@@ -25,8 +25,8 @@ class Table extends NodeList {
   /** @return var[][] */
   public function rows() {
     $rows= [];
-    foreach ($this->nodes as $row) {
-      $rows[]= $row->cells();
+    foreach ($this->nodes as $i => $row) {
+      $i && $rows[]= $row->cells();
     }
     return $rows;
   }

--- a/src/main/php/net/daringfireball/markdown/Table.class.php
+++ b/src/main/php/net/daringfireball/markdown/Table.class.php
@@ -16,11 +16,11 @@ class Table extends NodeList {
     return '<table>'.$r.'</table>';
   }
 
-  /** @return string[][] */
+  /** @return var[][] */
   public function rows() {
     $rows= [];
     foreach ($this->nodes as $row) {
-      $rows[]= array_map(function($cell) { return $cell->value; }, $row->nodes);
+      $rows[]= $row->cells();
     }
     return $rows;
   }

--- a/src/main/php/net/daringfireball/markdown/Table.class.php
+++ b/src/main/php/net/daringfireball/markdown/Table.class.php
@@ -1,0 +1,40 @@
+<?php namespace net\daringfireball\markdown;
+
+class Table extends NodeList {
+ 
+  /**
+   * Emit this table
+   *
+   * @param  [:net.daringfireball.markdown.Link] $definitions
+   * @return string
+   */
+  public function emit($definitions) {
+    $r= '';
+    foreach ($this->nodes as $row) {
+      $r.= $row->emit($definitions);
+    }
+    return '<table>'.$r.'</table>';
+  }
+
+  /** @return string[][] */
+  public function rows() {
+    $rows= [];
+    foreach ($this->nodes as $row) {
+      $rows[]= array_map(function($cell) { return $cell->value; }, $row->nodes);
+    }
+    return $rows;
+  }
+
+  /**
+   * Creates a string representation
+   *
+   * @return string
+   */
+  public function toString() {
+    $s= $this->getClassName()."@{\n";
+    foreach ($this->nodes as $row) {
+      $s.= '  '.$row->toString()."\n";
+    }
+    return $s.'}';
+  }
+}

--- a/src/main/php/net/daringfireball/markdown/TableContext.class.php
+++ b/src/main/php/net/daringfireball/markdown/TableContext.class.php
@@ -1,0 +1,51 @@
+<?php namespace net\daringfireball\markdown;
+
+class TableContext extends Context {
+
+  /**
+   * Parse a line into a row
+   *
+   * @param  string $line
+   * @param  string $line
+   * @return net.daringfireball.markdown.Row
+   */
+  private function parseRow($line, $type) {
+    $row= new Row($type);
+    foreach (explode('|', substr($line, 1, -1)) as $cell) {
+      $row->add(new Text(trim($cell)));
+    }
+    return $row;
+  }
+
+  /**
+   * Parse input into nodes
+   *
+   * @param  net.daringfireball.markdown.Input $lines
+   * @return net.daringfireball.markdown.Node
+   */
+  public function parse($lines) {
+    $table= new Table();
+    $table->add($this->parseRow($lines->nextLine(), 'th'));
+    $lines->nextLine();
+
+    while ($lines->hasMoreLines()) {
+      $line= $lines->nextLine();
+      if ('|' === $line{0}) {
+        $table->add($this->parseRow($line, 'td'));
+      } else {
+        break;
+      }
+    }
+
+    return $table;
+  }
+
+  /**
+   * Returns this context's name
+   *
+   * @return string
+   */
+  public function name() {
+    return 'table';
+  }
+}

--- a/src/main/php/net/daringfireball/markdown/TableContext.class.php
+++ b/src/main/php/net/daringfireball/markdown/TableContext.class.php
@@ -10,9 +10,9 @@ class TableContext extends Context {
    * @return net.daringfireball.markdown.Row
    */
   private function parseRow($line, $type) {
-    $row= new Row($type);
+    $row= new Row();
     foreach (explode('|', substr($line, 1, -1)) as $cell) {
-      $row->add(new Text(trim($cell)));
+      $this->tokenize(new Line(trim($cell)), $row->add(new Cell($type)));
     }
     return $row;
   }

--- a/src/main/php/net/daringfireball/markdown/WrappedTableContext.class.php
+++ b/src/main/php/net/daringfireball/markdown/WrappedTableContext.class.php
@@ -1,0 +1,18 @@
+<?php namespace net\daringfireball\markdown;
+
+class WrappedTableContext extends TableContext {
+
+  /**
+   * Parse a line into a cells
+   *
+   * @param  string $line
+   * @return string[]
+   */
+  protected function cellsIn($line) {
+    if ('|' === $line{0}) {
+      return explode('|', substr($line, 1, -1));
+    } else {
+      return null;
+    }
+  }
+}

--- a/src/test/php/net/daringfireball/markdown/unittest/TableTest.class.php
+++ b/src/test/php/net/daringfireball/markdown/unittest/TableTest.class.php
@@ -18,6 +18,15 @@ class TableTest extends MarkdownTest {
   }
 
   #[@test]
+  public function not_simple_layout() {
+    $this->assertTransformed(
+      "<p>Product | Price\nSecond Line</p>",
+      "Product | Price\n".
+      "Second Line"
+    );
+  }
+
+  #[@test]
   public function wrapped_layout() {
     $this->assertTransformed(
       '<table>'.
@@ -29,6 +38,15 @@ class TableTest extends MarkdownTest {
       "| ------- | ----- |\n".
       "| T-Shirt | 12.49 |\n".
       "| Server  | 99.99 |\n"
+    );
+  }
+
+  #[@test]
+  public function not_wrapped_layout() {
+    $this->assertTransformed(
+      "<p>| Product | Price |\nSecond Line</p>",
+      "| Product | Price |\n".
+      "Second Line"
     );
   }
 

--- a/src/test/php/net/daringfireball/markdown/unittest/TableTest.class.php
+++ b/src/test/php/net/daringfireball/markdown/unittest/TableTest.class.php
@@ -18,6 +18,21 @@ class TableTest extends MarkdownTest {
   }
 
   #[@test]
+  public function compact_layout() {
+    $this->assertTransformed(
+      '<table>'.
+      '<tr><th>Product</th><th>Price</th></tr>'.
+      '<tr><td>T-Shirt</td><td>12.49</td></tr>'.
+      '<tr><td>Server</td><td>99.99</td></tr>'.
+      '</table>',
+      "|Product|Price|\n".
+      "|-------|-----|\n".
+      "|T-Shirt|12.49|\n".
+      "|Server |99.99|\n"
+    );
+  }
+
+  #[@test]
   public function cells_may_contain_markup() {
     $this->assertTransformed(
       '<table>'.

--- a/src/test/php/net/daringfireball/markdown/unittest/TableTest.class.php
+++ b/src/test/php/net/daringfireball/markdown/unittest/TableTest.class.php
@@ -72,4 +72,20 @@ class TableTest extends MarkdownTest {
       "| T-Shirt |   S  | 12.49 |\n"
     );
   }
+
+  #[@test]
+  public function line_after_table() {
+    $this->assertTransformed(
+      '<table>'.
+      '<tr><th>Product</th><th>Price</th></tr>'.
+      '<tr><td>T-Shirt</td><td>12.49</td></tr>'.
+      '</table>'.
+      '<p>Line</p>',
+      "Product | Price\n".
+      "------- | -----\n".
+      "T-Shirt | 12.49\n".
+      "\n".
+      "Line"
+    );
+  }
 }

--- a/src/test/php/net/daringfireball/markdown/unittest/TableTest.class.php
+++ b/src/test/php/net/daringfireball/markdown/unittest/TableTest.class.php
@@ -3,7 +3,22 @@
 class TableTest extends MarkdownTest {
 
   #[@test]
-  public function table() {
+  public function simple_layout() {
+    $this->assertTransformed(
+      '<table>'.
+      '<tr><th>Product</th><th>Price</th></tr>'.
+      '<tr><td>T-Shirt</td><td>12.49</td></tr>'.
+      '<tr><td>Server</td><td>99.99</td></tr>'.
+      '</table>',
+      "Product | Price\n".
+      "------- | -----\n".
+      "T-Shirt | 12.49\n".
+      "Server  | 99.99\n"
+    );
+  }
+
+  #[@test]
+  public function wrapped_layout() {
     $this->assertTransformed(
       '<table>'.
       '<tr><th>Product</th><th>Price</th></tr>'.

--- a/src/test/php/net/daringfireball/markdown/unittest/TableTest.class.php
+++ b/src/test/php/net/daringfireball/markdown/unittest/TableTest.class.php
@@ -1,0 +1,19 @@
+<?php namespace net\daringfireball\markdown\unittest;
+
+class TableTest extends MarkdownTest {
+
+  #[@test]
+  public function unordered_list() {
+    $this->assertTransformed(
+      '<table>'.
+      '<tr><th>Product</th><th>Price</th></tr>'.
+      '<tr><td>T-Shirt</td><td>12.49</td></tr>'.
+      '<tr><td>Server</td><td>99.99</td></tr>'.
+      '</table>',
+      "| Product | Price |\n".
+      "| ------- | ----- |\n".
+      "| T-Shirt | 12.49 |\n".
+      "| Server  | 99.99 |\n"
+    );
+  }
+}

--- a/src/test/php/net/daringfireball/markdown/unittest/TableTest.class.php
+++ b/src/test/php/net/daringfireball/markdown/unittest/TableTest.class.php
@@ -44,4 +44,17 @@ class TableTest extends MarkdownTest {
       "| [T-Shirt](https://t-shirt.example.com/) | *$12.49* |\n"
     );
   }
+
+  #[@test]
+  public function alignment() {
+    $this->assertTransformed(
+      '<table>'.
+      '<tr><th style="text-align: left">Product</th><th style="text-align: center">Size</th><th style="text-align: right">Price</th></tr>'.
+      '<tr><td style="text-align: left">T-Shirt</td><td style="text-align: center">S</td><td style="text-align: right">12.49</td></tr>'.
+      '</table>',
+      "| Product | Size | Price |\n".
+      "|:--------|:----:|------:|\n".
+      "| T-Shirt |   S  | 12.49 |\n"
+    );
+  }
 }

--- a/src/test/php/net/daringfireball/markdown/unittest/TableTest.class.php
+++ b/src/test/php/net/daringfireball/markdown/unittest/TableTest.class.php
@@ -3,7 +3,7 @@
 class TableTest extends MarkdownTest {
 
   #[@test]
-  public function unordered_list() {
+  public function table() {
     $this->assertTransformed(
       '<table>'.
       '<tr><th>Product</th><th>Price</th></tr>'.
@@ -14,6 +14,19 @@ class TableTest extends MarkdownTest {
       "| ------- | ----- |\n".
       "| T-Shirt | 12.49 |\n".
       "| Server  | 99.99 |\n"
+    );
+  }
+
+  #[@test]
+  public function cells_may_contain_markup() {
+    $this->assertTransformed(
+      '<table>'.
+      '<tr><th>Product</th><th>Price</th></tr>'.
+      '<tr><td><a href="https://t-shirt.example.com/">T-Shirt</a></td><td><em>$12.49</em></td></tr>'.
+      '</table>',
+      "| Product | Price |\n".
+      "| ------- | ----- |\n".
+      "| [T-Shirt](https://t-shirt.example.com/) | *$12.49* |\n"
     );
   }
 }


### PR DESCRIPTION
This pull request adds supports for tables in markdown.

The following markdown:

```markdown
| Product | Price |
|---------|------:|
| T-Shirt | 12.49 |
| Server  | 99.99 |
```

...renders as:

| Product | Price |
|---------|------:|
| T-Shirt | 12.49 |
| Server  | 99.99 |

See https://michelf.ca/projects/php-markdown/extra/#table