### PR TITLE
Feature: Strike through

### DIFF
--- a/src/main/php/net/daringfireball/markdown/Markdown.class.php
+++ b/src/main/php/net/daringfireball/markdown/Markdown.class.php
@@ -73,12 +73,11 @@ class Markdown extends \lang\Object {
 
     $this->addToken('~', function($line, $target, $ctx) {
       if ($line->matches('~~')) {
-        $n= $line->chr(+2);
-        if (null === $n || false !== strpos("\r\n\t ", $n)) return false;
         if (null === ($delimited= $line->delimited('~~'))) return false;
         $target->add($ctx->tokenize(new Line($delimited), new StrikeThrough()));
+        return true;
       }
-      return true;
+      return false;
     });
 
     // Links and images: [A link](http://example.com), [A link](http://example.com "Title"),

--- a/src/main/php/net/daringfireball/markdown/Markdown.class.php
+++ b/src/main/php/net/daringfireball/markdown/Markdown.class.php
@@ -71,6 +71,16 @@ class Markdown extends \lang\Object {
     $this->addToken('*', $emphasis);
     $this->addToken('_', $emphasis);
 
+    $this->addToken('~', function($line, $target, $ctx) {
+      if ($line->matches('~~')) {
+        $n= $line->chr(+2);
+        if (null === $n || false !== strpos("\r\n\t ", $n)) return false;
+        if (null === ($delimited= $line->delimited('~~'))) return false;
+        $target->add($ctx->tokenize(new Line($delimited), new StrikeThrough()));
+      }
+      return true;
+    });
+
     // Links and images: [A link](http://example.com), [A link](http://example.com "Title"),
     // [Google][goog] reference-style link, [Google][] implicit name,and finally [Google] [1] 
     // numeric references (-> spaces allowed!). Images almost identical except for leading

--- a/src/main/php/net/daringfireball/markdown/StrikeThrough.class.php
+++ b/src/main/php/net/daringfireball/markdown/StrikeThrough.class.php
@@ -1,0 +1,8 @@
+<?php namespace net\daringfireball\markdown;
+
+class StrikeThrough extends NodeList {
+
+  public function emit($definitions) {
+    return '<del>'.parent::emit($definitions).'</del>';
+  }
+}

--- a/src/test/php/net/daringfireball/markdown/unittest/StrikeThroughTest.class.php
+++ b/src/test/php/net/daringfireball/markdown/unittest/StrikeThroughTest.class.php
@@ -1,0 +1,9 @@
+<?php namespace net\daringfireball\markdown\unittest;
+
+class StrikeThroughTest extends MarkdownTest {
+
+  #[@test]
+  public function strikethrough() {
+    $this->assertTransformed('<p><del>Hello</del></p>', '~~Hello~~');
+  }
+}

--- a/src/test/php/net/daringfireball/markdown/unittest/StrikeThroughTest.class.php
+++ b/src/test/php/net/daringfireball/markdown/unittest/StrikeThroughTest.class.php
@@ -6,4 +6,24 @@ class StrikeThroughTest extends MarkdownTest {
   public function strikethrough() {
     $this->assertTransformed('<p><del>Hello</del></p>', '~~Hello~~');
   }
+
+  #[@test]
+  public function first_word() {
+    $this->assertTransformed('<p><del>Hello</del> World</p>', '~~Hello~~ World');
+  }
+
+  #[@test]
+  public function second_word() {
+    $this->assertTransformed('<p>Hello <del>World</del></p>', 'Hello ~~World~~');
+  }
+
+  #[@test]
+  public function can_be_used_in_the_middle_of_a_word() {
+    $this->assertTransformed('<p>Strike<del>f</del>through</p>', 'Strike~~f~~through');
+  }
+
+  #[@test, @values(['a~~', 'b~~~'])]
+  public function reference_at_end($input) {
+    $this->assertTransformed('<p>'.$input.'</p>', $input);
+  }
 }

--- a/src/test/php/net/daringfireball/markdown/unittest/StrikeThroughTest.class.php
+++ b/src/test/php/net/daringfireball/markdown/unittest/StrikeThroughTest.class.php
@@ -22,8 +22,12 @@ class StrikeThroughTest extends MarkdownTest {
     $this->assertTransformed('<p>Strike<del>f</del>through</p>', 'Strike~~f~~through');
   }
 
-  #[@test, @values(['a~~', 'b~~~'])]
-  public function reference_at_end($input) {
+  #[@test, @values([
+  #  'a~', 'b~~', 'c~~~',
+  #  '~a', '~~b', '~~~c',
+  #  '~not~'
+  #])]
+  public function not_strikethrough($input) {
     $this->assertTransformed('<p>'.$input.'</p>', $input);
   }
 }


### PR DESCRIPTION
Implements the strike-through syntax via `~~`:
### Example
```markdown
~~Test~~
```
### Renders as
~~Test~~