### PR TITLE
XP9 Compat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ language: php
 
 sudo: false
 
+dist: trusty
+
 php:
   - 5.5
   - 5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,9 @@ matrix:
     - php: nightly
 
 before_script:
-  - wget 'https://github.com/xp-framework/xp-runners/releases/download/v6.3.0/setup' -O - | php
+  - curl -sSL https://dl.bintray.com/xp-runners/generic/xp-run-master.sh > xp-run
   - composer install --prefer-dist
   - echo "vendor/autoload.php" > composer.pth
-  - echo "use=vendor/xp-framework/core" > xp.ini
-  - echo "[runtime]" >> xp.ini
-  - echo "date.timezone=Europe/Berlin" >> xp.ini
 
 script:
-  - ./unittest src/test/php
+  - sh xp-run xp.unittest.TestRunner src/test/php

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ sudo: false
 dist: trusty
 
 php:
-  - 5.5
   - 5.6
   - 7.0
   - 7.1

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,11 @@ Markdown for XP Framework ChangeLog
 
 ## ?.?.? / ????-??-??
 
+## 4.0.0 / 2017-06-04
+
+* **Heads up:** Dropped PHP 5.5 support - @thekid
+* Added forward compatibility with XP 9.0.0 - @thekid
+
 ## 3.2.0 / 2016-11-05
 
 * Merged PR #9: Extract emitting HTML from nodes into emitter class

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "keywords": ["module", "xp"],
   "require" : {
     "xp-framework/core": "^8.0 | ^7.0 | ^6.5",
-    "php" : ">=5.5.0"
+    "php" : ">=5.6.0"
   },
   "require-dev" : {
     "xp-framework/unittest": "^7.0 | ^6.5"

--- a/composer.json
+++ b/composer.json
@@ -6,11 +6,11 @@
   "description" : "Markdown",
   "keywords": ["module", "xp"],
   "require" : {
-    "xp-framework/core": "^8.0 | ^7.0 | ^6.5",
+    "xp-framework/core": "^9.0 | ^8.0 | ^7.0 | ^6.5",
     "php" : ">=5.6.0"
   },
   "require-dev" : {
-    "xp-framework/unittest": "^7.0 | ^6.5"
+    "xp-framework/unittest": "^9.0 | ^8.0 | ^7.0 | ^6.5"
   },
   "autoload" : {
     "files" : ["src/main/php/autoload.php"]

--- a/src/main/php/net/daringfireball/markdown/BlockQuote.class.php
+++ b/src/main/php/net/daringfireball/markdown/BlockQuote.class.php
@@ -3,12 +3,13 @@
 class BlockQuote extends NodeList {
 
   /**
-   * Emit this blockquote element
+   * Emit this node
    *
-   * @param	 [:net.daringfireball.markdown.Link] definitions
+   * @param  net.daringfireball.markdown.Emitter $emitter
+   * @param  [:net.daringfireball.markdown.Link] $definitions
    * @return string
    */
-  public function emit($definitions) {
-    return '<blockquote>'.parent::emit($definitions).'</blockquote>';
+  public function emit($emitter, $definitions= []) {
+    return '<blockquote>'.parent::emit($emitter, $definitions).'</blockquote>';
   }
 }

--- a/src/main/php/net/daringfireball/markdown/Cell.class.php
+++ b/src/main/php/net/daringfireball/markdown/Cell.class.php
@@ -35,7 +35,7 @@ class Cell extends NodeList {
    * @return string
    */
   public function toString() {
-    return nameof($this).'(type= '.$this->type.', alignment= '.$this->alignment.')@'.\xp::stringOf($this->nodes);
+    return nameof($this).'(type= '.$this->type.', alignment= '.$this->alignment.')@'.Objects::stringOf($this->nodes);
   }
 
   /**

--- a/src/main/php/net/daringfireball/markdown/Code.class.php
+++ b/src/main/php/net/daringfireball/markdown/Code.class.php
@@ -1,16 +1,6 @@
 <?php namespace net\daringfireball\markdown;
 
-class Code extends Node {
-  public $value;
-
-  /**
-   * Creates a new code element
-   *
-   * @param string $value
-   */
-  public function __construct($value) {
-    $this->value= $value;
-  }
+class Code extends ValueNode {
 
   /**
    * Emit this node
@@ -21,25 +11,5 @@ class Code extends Node {
    */
   public function emit($emitter, $definitions= []) {
     return $emitter->emitCode($this, $definitions);
-  }
-
-  /** @return string */
-  public function toString() {
-    return nameof($this).'<'.$this->value.'>';
-  }
-
-  /** @return string */
-  public function hashCode() {
-    return '`'.md5($this->value);
-  }
-
-  /**
-   * Returns whether a given comparison value is equal to this node list
-   *
-   * @param  var $value
-   * @return string
-   */
-  public function compareTo($value) {
-    return $value instanceof self ? strcmp($this->value, $value->value) : 1;
   }
 }

--- a/src/main/php/net/daringfireball/markdown/Code.class.php
+++ b/src/main/php/net/daringfireball/markdown/Code.class.php
@@ -13,15 +13,6 @@ class Code extends Node {
   }
 
   /**
-   * Creates a string representation
-   *
-   * @return string
-   */
-  public function toString() {
-    return nameof($this).'<'.$this->value.'>';
-  }
-
-  /**
    * Emit this node
    *
    * @param  net.daringfireball.markdown.Emitter $emitter
@@ -30,5 +21,25 @@ class Code extends Node {
    */
   public function emit($emitter, $definitions= []) {
     return $emitter->emitCode($this, $definitions);
+  }
+
+  /** @return string */
+  public function toString() {
+    return nameof($this).'<'.$this->value.'>';
+  }
+
+  /** @return string */
+  public function hashCode() {
+    return '`'.md5($this->value);
+  }
+
+  /**
+   * Returns whether a given comparison value is equal to this node list
+   *
+   * @param  var $value
+   * @return string
+   */
+  public function compareTo($value) {
+    return $value instanceof self ? strcmp($this->value, $value->value) : 1;
   }
 }

--- a/src/main/php/net/daringfireball/markdown/Context.class.php
+++ b/src/main/php/net/daringfireball/markdown/Context.class.php
@@ -1,6 +1,8 @@
 <?php namespace net\daringfireball\markdown;
 
-abstract class Context extends \lang\Object {
+use util\Objects;
+
+abstract class Context implements \lang\Value {
   protected $tokens= [];
   protected $span= '';
 
@@ -80,11 +82,7 @@ abstract class Context extends \lang\Object {
     return $target;
   }
 
-  /**
-   * Creates a string representation of this context
-   *
-   * @return string
-   */
+  /** @return string */
   public function toString() {
     $s= 'net.daringfireball.markdown.Context('.$this->name();
     $parent= $this->parent;
@@ -93,5 +91,23 @@ abstract class Context extends \lang\Object {
       $parent= $parent->parent;
     }
     return $s.')';
+  }
+
+  /** @return string */
+  public function hashCode() {
+    return 'C'.Objects::hashOf([$this->tokens, $this->span]);
+  }
+
+  /**
+   * Compare
+   *
+   * @param  var $value
+   * @return int
+   */
+  public function compareTo($value) {
+    return $value instanceof self
+      ? Objects::compare([$this->tokens, $this->span], [$value->tokens, $value->span])
+      : 1
+    ;
   }
 }

--- a/src/main/php/net/daringfireball/markdown/Email.class.php
+++ b/src/main/php/net/daringfireball/markdown/Email.class.php
@@ -13,15 +13,6 @@ class Email extends Node {
   }
 
   /**
-   * Creates a string representation
-   *
-   * @return string
-   */
-  public function toString() {
-    return nameof($this).'<'.$this->address.'>';
-  }
-
-  /**
    * Emit this node
    *
    * @param  net.daringfireball.markdown.Emitter $emitter
@@ -30,5 +21,25 @@ class Email extends Node {
    */
   public function emit($emitter, $definitions= []) {
     return $emitter->emitEmail($this, $definitions);
+  }
+
+  /** @return string */
+  public function toString() {
+    return nameof($this).'<'.$this->address.'>';
+  }
+
+  /** @return string */
+  public function hashCode() {
+    return '@'.md5($this->address);
+  }
+
+  /**
+   * Returns whether a given comparison value is equal to this node list
+   *
+   * @param  var $value
+   * @return string
+   */
+  public function compareTo($value) {
+    return $value instanceof self ? strcmp($this->address, $value->address) : 1;
   }
 }

--- a/src/main/php/net/daringfireball/markdown/Entity.class.php
+++ b/src/main/php/net/daringfireball/markdown/Entity.class.php
@@ -1,33 +1,20 @@
 <?php namespace net\daringfireball\markdown;
 
-class Entity extends Node {
-  public $value;
-
-  public function __construct($value) {
-    $this->value= $value;
-  }
-
-  public function emit($definitions) {
-    return $this->value;
-  }
-
-  /** @return string */
-  public function toString() {
-    return nameof($this).'<'.$this->value.'>';
-  }
-
-  /** @return string */
-  public function hashCode() {
-    return '`'.md5($this->value);
-  }
+/**
+ * A HTML entity
+ *
+ * @test  xp://net.daringfireball.markdown.unittest.EntityTest
+ */
+class Entity extends ValueNode {
 
   /**
-   * Returns whether a given comparison value is equal to this node list
+   * Emit this node
    *
-   * @param  var $value
+   * @param  net.daringfireball.markdown.Emitter $emitter
+   * @param  [:net.daringfireball.markdown.Link] $definitions
    * @return string
    */
-  public function compareTo($value) {
-    return $value instanceof self ? strcmp($this->value, $value->value) : 1;
+  public function emit($emitter, $definitions= []) {
+    return $this->value;
   }
 }

--- a/src/main/php/net/daringfireball/markdown/Entity.class.php
+++ b/src/main/php/net/daringfireball/markdown/Entity.class.php
@@ -1,15 +1,33 @@
 <?php namespace net\daringfireball\markdown;
 
 class Entity extends Node {
+  public $value;
+
   public function __construct($value) {
     $this->value= $value;
   }
 
+  public function emit($definitions) {
+    return $this->value;
+  }
+
+  /** @return string */
   public function toString() {
     return nameof($this).'<'.$this->value.'>';
   }
 
-  public function emit($definitions) {
-    return $this->value;
+  /** @return string */
+  public function hashCode() {
+    return '`'.md5($this->value);
+  }
+
+  /**
+   * Returns whether a given comparison value is equal to this node list
+   *
+   * @param  var $value
+   * @return string
+   */
+  public function compareTo($value) {
+    return $value instanceof self ? strcmp($this->value, $value->value) : 1;
   }
 }

--- a/src/main/php/net/daringfireball/markdown/Header.class.php
+++ b/src/main/php/net/daringfireball/markdown/Header.class.php
@@ -12,7 +12,7 @@ class Header extends NodeList {
 
   /** @return string */
   public function toString() {
-    return nameof($this).'(h'.$this->level.')<'.Objects::stringOf($this->nodes).'>';
+    return nameof($this).'(h'.$this->level.')<'.$this->nodesIndented('  ').'>';
   }
 
   /**

--- a/src/main/php/net/daringfireball/markdown/Header.class.php
+++ b/src/main/php/net/daringfireball/markdown/Header.class.php
@@ -1,5 +1,7 @@
 <?php namespace net\daringfireball\markdown;
 
+use util\Objects;
+
 class Header extends NodeList {
   public $level;
 
@@ -10,7 +12,7 @@ class Header extends NodeList {
 
   /** @return string */
   public function toString() {
-    return nameof($this).'(h'.$this->level.')<'.\xp::stringOf($this->nodes).'>';
+    return nameof($this).'(h'.$this->level.')<'.Objects::stringOf($this->nodes).'>';
   }
 
   /**
@@ -20,7 +22,7 @@ class Header extends NodeList {
    * @param  [:net.daringfireball.markdown.Link] $definitions
    * @return string
    */
-  public function emit($definitions) {
-    return '<h'.$this->level.'>'.parent::emit($definitions).'</h'.$this->level.'>';
+  public function emit($emitter, $definitions= []) {
+    return '<h'.$this->level.'>'.parent::emit($emitter, $definitions).'</h'.$this->level.'>';
   }
 }

--- a/src/main/php/net/daringfireball/markdown/Image.class.php
+++ b/src/main/php/net/daringfireball/markdown/Image.class.php
@@ -19,21 +19,6 @@ class Image extends Node {
   }
 
   /**
-   * Creates a string representation
-   *
-   * @return string
-   */
-  public function toString() {
-    return sprintf(
-      '%s(url= %s, text= %s, title= %s)',
-      nameof($this),
-      $this->url,
-      \xp::stringOf($this->text),
-      \xp::stringOf($this->title)
-    );
-  }
-
-  /**
    * Emit this node
    *
    * @param  net.daringfireball.markdown.Emitter $emitter
@@ -44,18 +29,35 @@ class Image extends Node {
     return $emitter->emitImage($this, $definitions);
   }
 
+  /** @return string */
+  public function toString() {
+    return sprintf(
+      '%s(url= %s, text= %s, title= %s)',
+      nameof($this),
+      $this->url,
+      Objects::stringOf($this->text),
+      Objects::stringOf($this->title)
+    );
+  }
+
+  /** @return string */
+  public function hashCode() {
+    return '!'.Objects::hashOf([$this->url, $this->text, $this->title]);
+  }
+
   /**
    * Returns whether a given comparison value is equal to this node list
    *
-   * @param  var $cmp
+   * @param  var $value
    * @return string
    */
-  public function equals($cmp) {
-    return (
-      $cmp instanceof self &&
-      $this->url === $cmp->url &&
-      $this->title === $cmp->title &&
-      Objects::equal($this->text, $cmp->text)
-    );
+  public function compareTo($value) {
+    return $value instanceof self
+      ? Objects::compare(
+        [$this->url, $this->title, $this->text],
+        [$value->url, $value->title, $value->text]
+      )
+      : 1
+    ;
   }
 }

--- a/src/main/php/net/daringfireball/markdown/Image.class.php
+++ b/src/main/php/net/daringfireball/markdown/Image.class.php
@@ -35,7 +35,7 @@ class Image extends Node {
       '%s(url= %s, text= %s, title= %s)',
       nameof($this),
       $this->url,
-      Objects::stringOf($this->text),
+      $this->text ? Objects::stringOf($this->text) : 'null',
       Objects::stringOf($this->title)
     );
   }

--- a/src/main/php/net/daringfireball/markdown/Image.class.php
+++ b/src/main/php/net/daringfireball/markdown/Image.class.php
@@ -35,8 +35,8 @@ class Image extends Node {
       '%s(url= %s, text= %s, title= %s)',
       nameof($this),
       $this->url,
-      $this->text ? Objects::stringOf($this->text) : 'null',
-      Objects::stringOf($this->title)
+      null === $this->text ? 'null' : $this->text->toString(),
+      null === $this->title ? 'null' : '"'.$this->title.'"'
     );
   }
 

--- a/src/main/php/net/daringfireball/markdown/Input.class.php
+++ b/src/main/php/net/daringfireball/markdown/Input.class.php
@@ -1,9 +1,11 @@
 <?php namespace net\daringfireball\markdown;
 
+use util\Objects;
+
 /**
  * Abstract base class for input
  */
-abstract class Input extends \lang\Object {
+abstract class Input implements \lang\Value {
   protected $stack= [];
   protected $line= 1;
 
@@ -75,5 +77,26 @@ abstract class Input extends \lang\Object {
    */
   public function toString() {
     return nameof($this).'(line '.$this->line.' of '.$this->sourceDescription().')';
+  }
+
+  /** @return string */
+  public function hashCode() {
+    return md5($this->line.'@'.$this->sourceDescription());
+  }
+
+  /**
+   * Compare
+   *
+   * @param  var $value
+   * @return int
+   */
+  public function compareTo($value) {
+    return $value instanceof self
+      ? Objects::compare(
+        [$this->line, $this->sourceDescription()],
+        [$value->line, $value->sourceDescription()]
+      )
+      : 1
+    ;
   }
 }

--- a/src/main/php/net/daringfireball/markdown/Line.class.php
+++ b/src/main/php/net/daringfireball/markdown/Line.class.php
@@ -1,6 +1,8 @@
 <?php namespace net\daringfireball\markdown;
 
-class Line extends \lang\Object implements \ArrayAccess {
+use util\Objects;
+
+class Line implements \lang\Value, \ArrayAccess {
   protected $buffer;
   protected $pos;
   protected $length;
@@ -257,25 +259,29 @@ class Line extends \lang\Object implements \ArrayAccess {
   }
 
   /**
-   * Returns whether a given value is equal to this line
-   *
-   * @param  var $cmp The value
-   * @return bool
-   */
-  public function equals($cmp) {
-    return (
-      $this instanceof self &&
-      $this->buffer === $cmp->buffer &&
-      $this->pos === $cmp->pos
-    );
-  }
-
-  /**
    * Creates a string representation of this line
    *
    * @return string
    */
   public function toString() {
     return nameof($this).'("'.$this->buffer.'" @ '.$this->pos.')';
+  }
+
+  /** @return string */
+  public function hashCode() {
+    return 'L'.Objects::hashOf([$this->buffer, $this->pos]);
+  }
+
+  /**
+   * Compare
+   *
+   * @param  var $value
+   * @return int
+   */
+  public function compareTo($value) {
+    return $value instanceof self
+      ? Objects::compare([$this->buffer, $this->pos], [$value->buffer, $value->pos])
+      : 1
+    ;
   }
 }

--- a/src/main/php/net/daringfireball/markdown/Link.class.php
+++ b/src/main/php/net/daringfireball/markdown/Link.class.php
@@ -35,7 +35,7 @@ class Link extends Node {
       '%s(url= %s, text= %s, title= %s)',
       nameof($this),
       $this->url,
-      Objects::stringOf($this->text),
+      $this->text ? Objects::stringOf($this->text) : 'null',
       Objects::stringOf($this->title)
     );
   }

--- a/src/main/php/net/daringfireball/markdown/Link.class.php
+++ b/src/main/php/net/daringfireball/markdown/Link.class.php
@@ -19,21 +19,6 @@ class Link extends Node {
   }
 
   /**
-   * Creates a string representation
-   *
-   * @return string
-   */
-  public function toString() {
-    return sprintf(
-      '%s(url= %s, text= %s, title= %s)',
-      nameof($this),
-      $this->url,
-      \xp::stringOf($this->text),
-      \xp::stringOf($this->title)
-    );
-  }
-
-  /**
    * Emit this node
    *
    * @param  net.daringfireball.markdown.Emitter $emitter
@@ -44,18 +29,35 @@ class Link extends Node {
     return $emitter->emitLink($this, $definitions);
   }
 
+  /** @return string */
+  public function toString() {
+    return sprintf(
+      '%s(url= %s, text= %s, title= %s)',
+      nameof($this),
+      $this->url,
+      Objects::stringOf($this->text),
+      Objects::stringOf($this->title)
+    );
+  }
+
+  /** @return string */
+  public function hashCode() {
+    return '#'.Objects::hashOf([$this->url, $this->text, $this->title]);
+  }
+
   /**
    * Returns whether a given comparison value is equal to this node list
    *
-   * @param  var $cmp
+   * @param  var $value
    * @return string
    */
-  public function equals($cmp) {
-    return (
-      $cmp instanceof self &&
-      $this->url === $cmp->url &&
-      $this->title === $cmp->title &&
-      Objects::equal($this->text, $cmp->text)
-    );
+  public function compareTo($value) {
+    return $value instanceof self
+      ? Objects::compare(
+        [$this->url, $this->title, $this->text],
+        [$value->url, $value->title, $value->text]
+      )
+      : 1
+    ;
   }
 }

--- a/src/main/php/net/daringfireball/markdown/Link.class.php
+++ b/src/main/php/net/daringfireball/markdown/Link.class.php
@@ -35,8 +35,8 @@ class Link extends Node {
       '%s(url= %s, text= %s, title= %s)',
       nameof($this),
       $this->url,
-      $this->text ? Objects::stringOf($this->text) : 'null',
-      Objects::stringOf($this->title)
+      null === $this->text ? 'null' : $this->text->toString(),
+      null === $this->title ? 'null' : '"'.$this->title.'"'
     );
   }
 

--- a/src/main/php/net/daringfireball/markdown/Listing.class.php
+++ b/src/main/php/net/daringfireball/markdown/Listing.class.php
@@ -25,7 +25,7 @@ class Listing extends NodeList {
       nameof($this),
       $this->type,
       $this->paragraphs ? ' using paragraphs' : '',
-      \xp::stringOf($this->nodes)
+      $this->nodesIndented('  ')
     );
   }
 

--- a/src/main/php/net/daringfireball/markdown/Markdown.class.php
+++ b/src/main/php/net/daringfireball/markdown/Markdown.class.php
@@ -10,7 +10,7 @@ use lang\FormatException;
  * @see  https://github.com/markdown/markdown.github.com/wiki/Implementations
  * @test xp://net.daringfireball.markdown.unittest.MarkdownClassTest
  */
-class Markdown extends \lang\Object {
+class Markdown {
   protected $tokens= [];
   protected $handlers= [];
 

--- a/src/main/php/net/daringfireball/markdown/Markdown.class.php
+++ b/src/main/php/net/daringfireball/markdown/Markdown.class.php
@@ -215,8 +215,9 @@ class Markdown {
    * ```
    * The tokens handler needs to return whether it handled the token.
    * 
-   * @param string $char A single character starting the token
-   * @param var $handler The closure
+   * @param  string $char A single character starting the token
+   * @param  var $handler The closure
+   * @return void
    */
   public function addToken($char, $handler) {
     $this->tokens[$char]= $handler;
@@ -233,8 +234,9 @@ class Markdown {
    * };
    * ```
    *
-   * @param string $char A single character starting the token
-   * @param var $handler The closure
+   * @param  string $char A single character starting the token
+   * @param  var $handler The closure
+   * @return void
    */
   public function addHandler($pattern, $handler) {
     $this->handlers[$pattern]= $handler;

--- a/src/main/php/net/daringfireball/markdown/Markdown.class.php
+++ b/src/main/php/net/daringfireball/markdown/Markdown.class.php
@@ -254,11 +254,10 @@ class Markdown {
 
     $input= $in instanceof Input ? $in : new StringInput((string)$in);
     try {
-      $tree= $context->parse($input);
+      return $context->parse($input);
     } catch (Throwable $e) {
       throw new FormatException('Error in '.$input->toString(), $e);
     }
-    return $tree;
   }
 
   /**

--- a/src/main/php/net/daringfireball/markdown/Node.class.php
+++ b/src/main/php/net/daringfireball/markdown/Node.class.php
@@ -3,7 +3,7 @@
 /**
  * Abstract base class for all nodes and node lists
  */
-abstract class Node extends \lang\Object {
+abstract class Node {
 
   /**
    * Emit this node

--- a/src/main/php/net/daringfireball/markdown/Node.class.php
+++ b/src/main/php/net/daringfireball/markdown/Node.class.php
@@ -3,7 +3,7 @@
 /**
  * Abstract base class for all nodes and node lists
  */
-abstract class Node {
+abstract class Node implements \lang\Value {
 
   /**
    * Emit this node

--- a/src/main/php/net/daringfireball/markdown/NodeList.class.php
+++ b/src/main/php/net/daringfireball/markdown/NodeList.class.php
@@ -124,13 +124,25 @@ class NodeList extends Node {
     return $emitter->emitNodeList($this, $definitions);
   }
 
+  /**
+   * Returns nodes' string representation indented with a given indent
+   *
+   * @param  string $indent
+   * @return string
+   */
+  protected function nodesIndented($indent) {
+    if (empty($this->nodes)) return '';
+
+    $s= "\n";
+    foreach ($this->nodes as $node) {
+      $s.= $indent.str_replace("\n", "\n".$indent, $node->toString())."\n";
+    }
+    return $s;
+  }
+
   /** @return string */
   public function toString() {
-    $s= nameof($this)."@{\n";
-    foreach ($this->nodes as $node) {
-      $s.= '  '.str_replace("\n", "\n  ", $node->toString())."\n";
-    }
-    return $s.'}';
+    return nameof($this).'@{'.$this->nodesIndented('  ').'}';
   }
 
   /** @return string */

--- a/src/main/php/net/daringfireball/markdown/NodeList.class.php
+++ b/src/main/php/net/daringfireball/markdown/NodeList.class.php
@@ -110,15 +110,6 @@ class NodeList extends Node {
   }
 
   /**
-   * Creates a string representation
-   *
-   * @return string
-   */
-  public function toString() {
-    return nameof($this).'<'.\xp::stringOf($this->nodes).'>';
-  }
-
-  /**
    * Emit this parse tree
    *
    * @param  net.daringfireball.markdown.Emitter $emitter
@@ -129,13 +120,27 @@ class NodeList extends Node {
     return $emitter->emitNodeList($this, $definitions);
   }
 
+  /** @return string */
+  public function toString() {
+    $s= nameof($this)."@{\n";
+    foreach ($this->nodes as $node) {
+      $s.= '  '.str_replace("\n", "\n  ", $node->toString())."\n";
+    }
+    return $s.'}';
+  }
+
+  /** @return string */
+  public function hashCode() {
+    return '['.Objects::hashOf($this->nodes);
+  }
+
   /**
    * Returns whether a given comparison value is equal to this node list
    *
-   * @param  var $cmp
+   * @param  var $value
    * @return string
    */
-  public function equals($cmp) {
-    return $cmp instanceof self && Objects::equal($this->nodes, $cmp->nodes);
+  public function compareTo($value) {
+    return $value instanceof self ? Objects::compare($this->nodes, $value->nodes) : 1;
   }
 }

--- a/src/main/php/net/daringfireball/markdown/ParseTree.class.php
+++ b/src/main/php/net/daringfireball/markdown/ParseTree.class.php
@@ -35,21 +35,24 @@ class ParseTree extends NodeList {
   public function toString() {
     $s= '';
     foreach ($this->nodes as $node) {
-      $s.= '  '.str_replace("\n", "\n  ", $node->toString())."\n";
+      $s.= '    '.str_replace("\n", "\n    ", $node->toString())."\n";
     }
     return nameof($this)."@{\n".
-      "urls  : ".\xp::stringOf($this->urls)."\n".
-      "nodes : [\n".$s."]\n".
+      "  urls  : ".Objects::stringOf($this->urls)."\n".
+      "  nodes : [\n".$s."  ]\n".
     "}";
   }
 
   /**
-   * Returns whether a given comparison value is equal to this parse tree
+   * Returns whether a given comparison value is equal to this node list
    *
-   * @param  var $cmp
+   * @param  var $value
    * @return string
    */
-  public function equals($cmp) {
-    return parent::equals($cmp) && Objects::equal($this->urls, $cmp->urls);
+  public function compareTo($value) {
+    return $value instanceof self
+      ? Objects::compare([$this->urls, $this->nodes], [$value->urls, $value->nodes])
+      : 1
+    ;
   }
 }

--- a/src/main/php/net/daringfireball/markdown/Ruler.class.php
+++ b/src/main/php/net/daringfireball/markdown/Ruler.class.php
@@ -5,4 +5,24 @@ class Ruler extends Node {
   public function emit($definitions) {
     return '<hr/>';
   }
+
+  /** @return string */
+  public function toString() {
+    return nameof($this);
+  }
+
+  /** @return string */
+  public function hashCode() {
+    return '---';
+  }
+
+  /**
+   * Returns whether a given comparison value is equal to this node list
+   *
+   * @param  var $value
+   * @return string
+   */
+  public function compareTo($value) {
+    return $value instanceof self ? 0 : 1;
+  }
 }

--- a/src/main/php/net/daringfireball/markdown/Ruler.class.php
+++ b/src/main/php/net/daringfireball/markdown/Ruler.class.php
@@ -1,20 +1,28 @@
 <?php namespace net\daringfireball\markdown;
 
+/**
+ * A (horizontal) ruler
+ *
+ * @test  xp://net.daringfireball.markdown.unittest.RulerTest
+ */
 class Ruler extends Node {
 
-  public function emit($definitions) {
+  /**
+   * Emit this node
+   *
+   * @param  net.daringfireball.markdown.Emitter $emitter
+   * @param  [:net.daringfireball.markdown.Link] $definitions
+   * @return string
+   */
+  public function emit($emitter, $definitions= []) {
     return '<hr/>';
   }
 
   /** @return string */
-  public function toString() {
-    return nameof($this);
-  }
+  public function toString() { return nameof($this); }
 
   /** @return string */
-  public function hashCode() {
-    return '---';
-  }
+  public function hashCode() { return '---'; }
 
   /**
    * Returns whether a given comparison value is equal to this node list
@@ -22,7 +30,5 @@ class Ruler extends Node {
    * @param  var $value
    * @return string
    */
-  public function compareTo($value) {
-    return $value instanceof self ? 0 : 1;
-  }
+  public function compareTo($value) { return $value instanceof self ? 0 : 1; }
 }

--- a/src/main/php/net/daringfireball/markdown/Text.class.php
+++ b/src/main/php/net/daringfireball/markdown/Text.class.php
@@ -5,17 +5,7 @@
  *
  * @test  xp://net.daringfireball.markdown.unittest.TextNodeTest
  */
-class Text extends Node {
-  public $value;
-
-  /**
-   * Creates a new fragment of text
-   *
-   * @param  string value
-   */
-  public function __construct($value= '') {
-    $this->value= $value;
-  }
+class Text extends ValueNode {
 
   /**
    * Emit this node
@@ -26,25 +16,5 @@ class Text extends Node {
    */
   public function emit($emitter, $definitions= []) {
     return $emitter->emitText($this, $definitions);
-  }
-
-  /** @return string */
-  public function toString() {
-    return nameof($this).'<'.$this->value.'>';
-  }
-
-  /** @return string */
-  public function hashCode() {
-    return '"'.md5($this->value);
-  }
-
-  /**
-   * Returns whether a given comparison value is equal to this node list
-   *
-   * @param  var $value
-   * @return string
-   */
-  public function compareTo($value) {
-    return $value instanceof self ? strcmp($this->value, $value->value) : 1;
   }
 }

--- a/src/main/php/net/daringfireball/markdown/Text.class.php
+++ b/src/main/php/net/daringfireball/markdown/Text.class.php
@@ -18,15 +18,6 @@ class Text extends Node {
   }
 
   /**
-   * Creates a string representation
-   *
-   * @return string
-   */
-  public function toString() {
-    return nameof($this).'<'.$this->value.'>';
-  }
-
-  /**
    * Emit this node
    *
    * @param  net.daringfireball.markdown.Emitter $emitter
@@ -37,13 +28,23 @@ class Text extends Node {
     return $emitter->emitText($this, $definitions);
   }
 
+  /** @return string */
+  public function toString() {
+    return nameof($this).'<'.$this->value.'>';
+  }
+
+  /** @return string */
+  public function hashCode() {
+    return '"'.md5($this->value);
+  }
+
   /**
    * Returns whether a given comparison value is equal to this node list
    *
-   * @param  var $cmp
+   * @param  var $value
    * @return string
    */
-  public function equals($cmp) {
-    return $cmp instanceof self && $this->value === $cmp->value;
+  public function compareTo($value) {
+    return $value instanceof self ? strcmp($this->value, $value->value) : 1;
   }
 }

--- a/src/main/php/net/daringfireball/markdown/ValueNode.class.php
+++ b/src/main/php/net/daringfireball/markdown/ValueNode.class.php
@@ -1,0 +1,35 @@
+<?php namespace net\daringfireball\markdown;
+
+abstract class ValueNode extends Node {
+  public $value;
+
+  /**
+   * Creates a new box
+   *
+   * @param  var $value
+   */
+  public function __construct($value= '') {
+    $this->value= $value;
+  }
+
+
+  /** @return string */
+  public function toString() {
+    return nameof($this).'<'.$this->value.'>';
+  }
+
+  /** @return string */
+  public function hashCode() {
+    return md5(static::class.$this->value);
+  }
+
+  /**
+   * Returns whether a given comparison value is equal to this node list
+   *
+   * @param  var $value
+   * @return string
+   */
+  public function compareTo($value) {
+    return $value instanceof self ? strcmp($this->value, $value->value) : 1;
+  }
+}

--- a/src/test/php/net/daringfireball/markdown/unittest/CodeTest.class.php
+++ b/src/test/php/net/daringfireball/markdown/unittest/CodeTest.class.php
@@ -1,5 +1,7 @@
 <?php namespace net\daringfireball\markdown\unittest;
 
+use net\daringfireball\markdown\Code;
+
 class CodeTest extends MarkdownTest {
 
   #[@test]
@@ -129,5 +131,13 @@ class CodeTest extends MarkdownTest {
   #])]
   public function unmatched_backticks($input) {
     $this->assertTransformed('<p>'.$input.'</p>', $input);
+  }
+
+  #[@test]
+  public function string_representation() {
+    $this->assertEquals(
+      'net.daringfireball.markdown.Code<1 + 2>',
+      (new Code('1 + 2'))->toString()
+    );
   }
 }

--- a/src/test/php/net/daringfireball/markdown/unittest/EntityTest.class.php
+++ b/src/test/php/net/daringfireball/markdown/unittest/EntityTest.class.php
@@ -1,0 +1,24 @@
+<?php namespace net\daringfireball\markdown\unittest;
+
+use net\daringfireball\markdown\Entity;
+
+class EntityTest extends MarkdownTest {
+
+  #[@test]
+  public function standalone_entity() {
+    $this->assertTransformed('<p>&amp;</p>', '&amp;');
+  }
+
+  #[@test]
+  public function entity_between_letters() {
+    $this->assertTransformed('<p>AT&amp;T</p>', 'AT&amp;T');
+  }
+
+  #[@test]
+  public function string_representation() {
+    $this->assertEquals(
+      'net.daringfireball.markdown.Entity<&amp;>',
+      (new Entity('&amp;'))->toString()
+    );
+  }
+}

--- a/src/test/php/net/daringfireball/markdown/unittest/ImagesTest.class.php
+++ b/src/test/php/net/daringfireball/markdown/unittest/ImagesTest.class.php
@@ -1,5 +1,8 @@
 <?php namespace net\daringfireball\markdown\unittest;
 
+use net\daringfireball\markdown\Image;
+use net\daringfireball\markdown\Text;
+
 class ImagesTest extends MarkdownTest {
 
   #[@test]
@@ -35,6 +38,31 @@ class ImagesTest extends MarkdownTest {
     $this->assertTransformed(
       '<p>This is ! an image</p>',
       'This is ! an image'
+    );
+  }
+
+  #[@test]
+  public function string_representation() {
+    $this->assertEquals(
+      'net.daringfireball.markdown.Image(url= http://example.com/test.gif, text= null, title= null)',
+      (new Image('http://example.com/test.gif'))->toString()
+    );
+  }
+
+  #[@test]
+  public function string_representation_with_text() {
+    $t= new Text('example');
+    $this->assertEquals(
+      'net.daringfireball.markdown.Image(url= http://example.com/test.gif, text= '.$t->toString().', title= null)',
+      (new Image('http://example.com/test.gif', $t))->toString()
+    );
+  }
+
+  #[@test]
+  public function string_representation_with_title() {
+    $this->assertEquals(
+      'net.daringfireball.markdown.Image(url= http://example.com/test.gif, text= null, title= "Test")',
+      (new Image('http://example.com/test.gif', null, 'Test'))->toString()
     );
   }
 }

--- a/src/test/php/net/daringfireball/markdown/unittest/LineTest.class.php
+++ b/src/test/php/net/daringfireball/markdown/unittest/LineTest.class.php
@@ -335,4 +335,12 @@ class LineTest extends \unittest\TestCase {
     $l= new Line('');
     $this->assertFalse(isset($l{0}));
   }
+
+  #[@test]
+  public function string_representation() {
+    $this->assertEquals(
+      'net.daringfireball.markdown.Line("Hello" @ 2)',
+      (new Line('Hello', 2))->toString()
+    );
+  }
 }

--- a/src/test/php/net/daringfireball/markdown/unittest/LinksTest.class.php
+++ b/src/test/php/net/daringfireball/markdown/unittest/LinksTest.class.php
@@ -1,5 +1,8 @@
 <?php namespace net\daringfireball\markdown\unittest;
 
+use net\daringfireball\markdown\Link;
+use net\daringfireball\markdown\Text;
+
 class LinksTest extends MarkdownTest {
 
   #[@test]
@@ -208,6 +211,31 @@ class LinksTest extends MarkdownTest {
     $this->assertTransformed(
       '<p>This is [not a link], man.</p>',
       'This is [not a link], man.'
+    );
+  }
+
+  #[@test]
+  public function string_representation() {
+    $this->assertEquals(
+      'net.daringfireball.markdown.Link(url= http://example.com, text= null, title= null)',
+      (new Link('http://example.com'))->toString()
+    );
+  }
+
+  #[@test]
+  public function string_representation_with_text() {
+    $t= new Text('example');
+    $this->assertEquals(
+      'net.daringfireball.markdown.Link(url= http://example.com, text= '.$t->toString().', title= null)',
+      (new Link('http://example.com', $t))->toString()
+    );
+  }
+
+  #[@test]
+  public function string_representation_with_title() {
+    $this->assertEquals(
+      'net.daringfireball.markdown.Link(url= http://example.com, text= null, title= "Test")',
+      (new Link('http://example.com', null, 'Test'))->toString()
     );
   }
 }

--- a/src/test/php/net/daringfireball/markdown/unittest/RulerTest.class.php
+++ b/src/test/php/net/daringfireball/markdown/unittest/RulerTest.class.php
@@ -1,9 +1,19 @@
 <?php namespace net\daringfireball\markdown\unittest;
 
+use net\daringfireball\markdown\Ruler;
+
 class RulerTest extends MarkdownTest {
 
   #[@test, @values(['* * *', '***', '*****'])]
   public function with_asterisks($input) {
     $this->assertTransformed('<hr/>', $input);
+  }
+
+  #[@test]
+  public function string_representation() {
+    $this->assertEquals(
+      'net.daringfireball.markdown.Ruler',
+      (new Ruler())->toString()
+    );
   }
 }


### PR DESCRIPTION
This pull request:

* Adds XP9 forward compatibility by classes implementing `lang.Value` instead of extending `lang.Object`
* Drops PHP 5.5 support
* Cleans up string representations of parse tree and node
* Contains slight QA refactorings.
* Changes code to no longer use `xp::stringOf()`
