### PR TITLE
Also accept io.streams.TextReader instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Markdown for XP Framework
 [![Build Status on TravisCI](https://secure.travis-ci.org/xp-forge/markdown.svg)](http://travis-ci.org/xp-forge/markdown)
 [![XP Framework Module](https://raw.githubusercontent.com/xp-framework/web/master/static/xp-framework-badge.png)](https://github.com/xp-framework/core)
 [![BSD Licence](https://raw.githubusercontent.com/xp-framework/web/master/static/licence-bsd.png)](https://github.com/xp-framework/core/blob/master/LICENCE.md)
-[![Required PHP 5.5+](https://raw.githubusercontent.com/xp-framework/web/master/static/php-5_5plus.png)](http://php.net/)
+[![Required PHP 5.6+](https://raw.githubusercontent.com/xp-framework/web/master/static/php-5_6plus.png)](http://php.net/)
 [![Supports PHP 7.0+](https://raw.githubusercontent.com/xp-framework/web/master/static/php-7_0plus.png)](http://php.net/)
 [![Supports HHVM 3.4+](https://raw.githubusercontent.com/xp-framework/web/master/static/hhvm-3_4plus.png)](http://hhvm.com/)
 [![Latest Stable Version](https://poser.pugx.org/xp-forge/markdown/version.png)](https://packagist.org/packages/xp-forge/markdown)

--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ The implementation is based on a parse tree. To work with the tree, you can use 
 
 ```php
 use net\daringfireball\markdown\{Markdown, ToHtml};
+use io\streams\TextReader;
+use io\File;
 
 $engine= new Markdown();
-$tree= $engine->parse(
-  'This is [Markdown](http://daringfireball.net/projects/markdown/) for **XP**'
-);
+$tree= $engine->parse(new TextReader(new File('file.md')));
 
 // ...work with tree...
 

--- a/src/main/php/net/daringfireball/markdown/Input.class.php
+++ b/src/main/php/net/daringfireball/markdown/Input.class.php
@@ -1,6 +1,7 @@
 <?php namespace net\daringfireball\markdown;
 
 use util\Objects;
+use io\streams\Reader;
 
 /**
  * Abstract base class for input
@@ -8,6 +9,22 @@ use util\Objects;
 abstract class Input implements \lang\Value {
   protected $stack= [];
   protected $line= 1;
+
+  /**
+   * Creates a new input from a given argument
+   *
+   * @param  string|self|io.streams.Reader $arg
+   * @return self
+   */
+  public static function from($arg) {
+    if ($arg instanceof self) {
+      return $arg;
+    } else if ($arg instanceof Reader) {
+      return new ReaderInput($arg);
+    } else {
+      return new StringInput((string)$arg);
+    }
+  }
 
   /**
    * Returns current line numer

--- a/src/main/php/net/daringfireball/markdown/Input.class.php
+++ b/src/main/php/net/daringfireball/markdown/Input.class.php
@@ -1,7 +1,7 @@
 <?php namespace net\daringfireball\markdown;
 
 use util\Objects;
-use io\streams\Reader;
+use io\streams\TextReader;
 
 /**
  * Abstract base class for input
@@ -13,13 +13,13 @@ abstract class Input implements \lang\Value {
   /**
    * Creates a new input from a given argument
    *
-   * @param  string|self|io.streams.Reader $arg
+   * @param  string|self|io.streams.TextReader $arg
    * @return self
    */
   public static function from($arg) {
     if ($arg instanceof self) {
       return $arg;
-    } else if ($arg instanceof Reader) {
+    } else if ($arg instanceof TextReader) {
       return new ReaderInput($arg);
     } else {
       return new StringInput((string)$arg);

--- a/src/main/php/net/daringfireball/markdown/Markdown.class.php
+++ b/src/main/php/net/daringfireball/markdown/Markdown.class.php
@@ -260,7 +260,7 @@ class Markdown {
   /**
    * Parses the output and returns the resulting parse tree
    *
-   * @param  string|net.daringfireball.markdown.Input|io.streams.Reader $in markdown
+   * @param  string|net.daringfireball.markdown.Input|io.streams.TextReader $in markdown
    * @return net.daringfireball.markdown.ParseTree
    * @throws lang.FormatException
    */
@@ -277,7 +277,7 @@ class Markdown {
   /**
    * Transform a given input and returns the output
    *
-   * @param  var $in markdown either a string or a net.daringfireball.markdown.Input
+   * @param  string|net.daringfireball.markdown.Input|io.streams.TextReader $in markdown
    * @param  [:net.daringfireball.markdown.Link] $urls
    * @param  net.daringfireball.markdown.Emitter $emitter Defaults to HTML
    * @return string markup

--- a/src/main/php/net/daringfireball/markdown/Markdown.class.php
+++ b/src/main/php/net/daringfireball/markdown/Markdown.class.php
@@ -260,14 +260,13 @@ class Markdown {
   /**
    * Parses the output and returns the resulting parse tree
    *
-   * @param  string|net.daringfireball.markdown.Input $in markdown
+   * @param  string|net.daringfireball.markdown.Input|io.streams.Reader $in markdown
    * @return net.daringfireball.markdown.ParseTree
    * @throws lang.FormatException
    */
   public function parse($in) {
     $context= (new ToplevelContext())->withTokens($this->tokens)->withHandlers($this->handlers);
-
-    $input= $in instanceof Input ? $in : new StringInput((string)$in);
+    $input= Input::from($in);
     try {
       return $context->parse($input);
     } catch (Throwable $e) {

--- a/src/main/php/net/daringfireball/markdown/ReaderInput.class.php
+++ b/src/main/php/net/daringfireball/markdown/ReaderInput.class.php
@@ -1,5 +1,7 @@
 <?php namespace net\daringfireball\markdown;
 
+use io\streams\TextReader;
+
 /**
  * Input implementation for stream readers
  *
@@ -11,9 +13,9 @@ class ReaderInput extends Input {
   /**
    * Creates a new reader input instance
    *
-   * @param  io.streams.Reader $reader
+   * @param  io.streams.TextReader $reader
    */
-  public function __construct(\io\streams\Reader $reader) {
+  public function __construct(TextReader $reader) {
     $this->reader= $reader;
   }
 

--- a/src/test/php/net/daringfireball/markdown/unittest/MarkdownClassTest.class.php
+++ b/src/test/php/net/daringfireball/markdown/unittest/MarkdownClassTest.class.php
@@ -31,6 +31,13 @@ class MarkdownClassTest extends MarkdownTest {
   }
 
   #[@test]
+  public function transform_reader() {
+    $this->assertEquals('<p></p>', (new Markdown())->transform(
+      new TextReader(new MemoryInputStream(''))
+    ));
+  }
+
+  #[@test]
   public function transform_string_input() {
     $this->assertEquals('<p></p>', (new Markdown())->transform(new StringInput('')));
   }


### PR DESCRIPTION
This pull request adds TextReader instances as valid input for `parse()` and `transform()`.

```php
$markdown= new Markdown();

// Current
$tree= $markdown->parse(new ReaderInput(new TextReader(...)));

// New
$tree= $markdown->parse(new TextReader(...));

// New: Reading from a file
$tree= $markdown->parse(new TextReader(new File('origin.md')));

// New: Reading from a stream
$tree= $markdown->parse(new TextReader($http->get()->in()));

// New: Reading from the console
$tree= $markdown->parse(new TextReader(Console::$in->getStream()));
```
