### PR TITLE
Emit code blocks as <code> wrapped in <pre>

### DIFF
--- a/src/main/php/net/daringfireball/markdown/ToHtml.class.php
+++ b/src/main/php/net/daringfireball/markdown/ToHtml.class.php
@@ -270,7 +270,7 @@ class ToHtml implements Emitter {
     }
 
     $attr= $block->language ? ' lang="'.htmlspecialchars($block->language, $this->flags).'"' : '';
-    return '<code'.$attr.'>'.$r.'</code>';
+    return '<pre><code'.$attr.'>'.$r.'</code></pre>';
   }
 
   /**

--- a/src/test/php/net/daringfireball/markdown/unittest/CodeTest.class.php
+++ b/src/test/php/net/daringfireball/markdown/unittest/CodeTest.class.php
@@ -82,7 +82,7 @@ class CodeTest extends MarkdownTest {
   #[Test]
   public function indented_with_four_spaces() {
     $this->assertTransformed(
-      '<code>10 GOTO 10</code>',
+      '<pre><code>10 GOTO 10</code></pre>',
       '    10 GOTO 10'
     );
   }
@@ -90,7 +90,7 @@ class CodeTest extends MarkdownTest {
   #[Test]
   public function indented_with_one_tab() {
     $this->assertTransformed(
-      '<code>10 GOTO 10</code>',
+      '<pre><code>10 GOTO 10</code></pre>',
       "\t10 GOTO 10"
     );
   }
@@ -98,7 +98,7 @@ class CodeTest extends MarkdownTest {
   #[Test]
   public function two_lines_indented_with_four_spaces() {
     $this->assertTransformed(
-      "<code>10 PRINT &quot;HI&quot;\n20 GOTO 10</code>",
+      "<pre><code>10 PRINT &quot;HI&quot;\n20 GOTO 10</code></pre>",
       "    10 PRINT \"HI\"\n    20 GOTO 10"
     );
   }
@@ -106,7 +106,7 @@ class CodeTest extends MarkdownTest {
   #[Test]
   public function github_style_fenced_block() {
     $this->assertTransformed(
-      "<code>10 PRINT &quot;HI&quot;\n20 GOTO 10</code>",
+      "<pre><code>10 PRINT &quot;HI&quot;\n20 GOTO 10</code></pre>",
       "```\n10 PRINT \"HI\"\n20 GOTO 10\n```"
     );
   }
@@ -114,7 +114,7 @@ class CodeTest extends MarkdownTest {
   #[Test]
   public function github_style_fenced_block_with_language() {
     $this->assertTransformed(
-      "<code lang=\"basic\">10 PRINT &quot;HI&quot;\n20 GOTO 10</code>",
+      "<pre><code lang=\"basic\">10 PRINT &quot;HI&quot;\n20 GOTO 10</code></pre>",
       "```basic\n10 PRINT \"HI\"\n20 GOTO 10\n```"
     );
   }


### PR DESCRIPTION
See #16. As far as I see from here https://github.com/commonmark/commonmark-spec/blob/8dbbe341608cf37d7fe9c3157c15e09cbbe359ce/alternative-html-blocks.txt#L165, https://spec.commonmark.org/0.30/#code-spans and https://spec.commonmark.org/0.30/#fenced-code-block this would also what the spec would expect.

*⚠️: This is a BC break and would result in a major release, 7.0.0 at the time of writing.* 