### PR TITLE
Add support for fenced code blocks enclosed with `~~~`

### DIFF
--- a/src/main/php/net/daringfireball/markdown/FencedCodeContext.class.php
+++ b/src/main/php/net/daringfireball/markdown/FencedCodeContext.class.php
@@ -1,10 +1,11 @@
 <?php namespace net\daringfireball\markdown;
 
 class FencedCodeContext extends Context {
-  protected $language= '';
+  protected $language, $fence;
 
-  public function __construct($language) {
+  public function __construct($language, $fence= '```') {
     $this->language= $language;
+    $this->fence= $fence;
   }
 
   /**
@@ -18,7 +19,7 @@ class FencedCodeContext extends Context {
 
     while ($lines->hasMoreLines()) {
       $line= $lines->nextLine();
-      if (0 === strncmp($line, '```', 3)) {
+      if (0 === strncmp($line, $this->fence, 3)) {
         break;
       } else {
         $result->add(new Text($line));

--- a/src/main/php/net/daringfireball/markdown/Markdown.class.php
+++ b/src/main/php/net/daringfireball/markdown/Markdown.class.php
@@ -191,8 +191,8 @@ class Markdown {
       $result->append($ctx->enter(new CodeContext())->parse($lines));
       return true;
     });
-    $this->addHandler('/^```(.*)/', function($lines, $matches, $result, $ctx) { 
-      $result->append($ctx->enter(new FencedCodeContext($matches[1]))->parse($lines));
+    $this->addHandler('/^(```|~~~)(.*)/', function($lines, $matches, $result, $ctx) { 
+      $result->append($ctx->enter(new FencedCodeContext($matches[2], $matches[1]))->parse($lines));
       return true;
     });
     $this->addHandler('/^\|.+\| *$/', function($lines, $matches, $result, $ctx) {

--- a/src/test/php/net/daringfireball/markdown/unittest/CodeTest.class.php
+++ b/src/test/php/net/daringfireball/markdown/unittest/CodeTest.class.php
@@ -1,8 +1,7 @@
 <?php namespace net\daringfireball\markdown\unittest;
 
 use net\daringfireball\markdown\{Code, CodeBlock, Text};
-use test\Assert;
-use test\{Test, Values};
+use test\{Assert, Test, Values};
 
 class CodeTest extends MarkdownTest {
 
@@ -103,19 +102,19 @@ class CodeTest extends MarkdownTest {
     );
   }
 
-  #[Test]
-  public function github_style_fenced_block() {
+  #[Test, Values(['```', '~~~'])]
+  public function github_style_fenced_block($fence) {
     $this->assertTransformed(
       "<code>10 PRINT &quot;HI&quot;\n20 GOTO 10</code>",
-      "```\n10 PRINT \"HI\"\n20 GOTO 10\n```"
+      "{$fence}\n10 PRINT \"HI\"\n20 GOTO 10\n{$fence}"
     );
   }
 
-  #[Test]
-  public function github_style_fenced_block_with_language() {
+  #[Test, Values(['```', '~~~'])]
+  public function github_style_fenced_block_with_language($fence) {
     $this->assertTransformed(
       "<code lang=\"basic\">10 PRINT &quot;HI&quot;\n20 GOTO 10</code>",
-      "```basic\n10 PRINT \"HI\"\n20 GOTO 10\n```"
+      "{$fence}basic\n10 PRINT \"HI\"\n20 GOTO 10\n{$fence}"
     );
   }
 

--- a/src/test/php/net/daringfireball/markdown/unittest/StrikeThroughTest.class.php
+++ b/src/test/php/net/daringfireball/markdown/unittest/StrikeThroughTest.class.php
@@ -25,7 +25,7 @@ class StrikeThroughTest extends MarkdownTest {
     $this->assertTransformed('<p>Strike<del>f</del>through</p>', 'Strike~~f~~through');
   }
 
-  #[Test, Values(['a~', 'b~~', 'c~~~', '~a', '~~b', '~~~c', '~not~'])]
+  #[Test, Values(['a~', 'b~~', 'c~~~', '~a', '~~b', '~not~'])]
   public function not_strikethrough($input) {
     $this->assertTransformed('<p>'.$input.'</p>', $input);
   }


### PR DESCRIPTION
```markdown
This is fenced code block with tildes:

~~~php
echo PHP_VERSION;
~~~
```

See https://spec.commonmark.org/0.30/#fenced-code-blocks
