### PR TITLE
Fix formatting inide lists

### DIFF
--- a/src/main/php/net/daringfireball/markdown/BlockquoteContext.class.php
+++ b/src/main/php/net/daringfireball/markdown/BlockquoteContext.class.php
@@ -1,16 +1,6 @@
 <?php namespace net\daringfireball\markdown;
 
 class BlockquoteContext extends Context {
-  public $handlers;
-
-  /**
-   * Creates a new block quote context
-   *
-   * @param  [:var] $handlers
-   */
-  public function __construct($handlers) {
-    $this->handlers= $handlers;
-  }
 
   /**
    * Parse input into nodes

--- a/src/main/php/net/daringfireball/markdown/Context.class.php
+++ b/src/main/php/net/daringfireball/markdown/Context.class.php
@@ -1,9 +1,11 @@
 <?php namespace net\daringfireball\markdown;
 
 use util\Objects;
+use lang\Value;
 
-abstract class Context implements \lang\Value {
+abstract class Context implements Value {
   protected $tokens= [];
+  protected $handlers= [];
   protected $span= '';
 
   /**
@@ -14,23 +16,33 @@ abstract class Context implements \lang\Value {
    */
   public function enter(self $context) {
     $context->tokens= $this->tokens;
+    $context->handlers= $this->handlers;
     $context->span= $this->span;
     return $context;
   }
 
-  /** @deprecated - Use withTokens() instead! */
-  public function setTokens($tokens) { $this->withTokens($tokens); }
-
   /**
    * Sets token handlers
    * 
-   * @param  [:var] tokens
+   * @param  [:var] $tokens
    * @return self
-   * @see    xp://net.daringfireball.markdown.Markdown#addToken
+   * @see    net.daringfireball.markdown.Markdown::addToken
    */
   public function withTokens($tokens) {
     $this->tokens= $tokens;
     $this->span= '\\'.implode('', array_keys($tokens));
+    return $this;
+  }
+
+  /**
+   * Sets line handlers
+   *
+   * @param  [:var] $handlers
+   * @return self
+   * @see    net.daringfireball.markdown.Markdown::addHandler
+   */
+  public function withHandlers($handlers) {
+    $this->handlers= $handlers;
     return $this;
   }
 

--- a/src/main/php/net/daringfireball/markdown/Input.class.php
+++ b/src/main/php/net/daringfireball/markdown/Input.class.php
@@ -2,13 +2,13 @@
 
 use io\streams\TextReader;
 use util\Objects;
+use lang\Value;
 
-/**
- * Abstract base class for input
- */
-abstract class Input implements \lang\Value {
+/** Abstract base class for input */
+abstract class Input implements Value {
   protected $stack= [];
   protected $line= 1;
+  public $indent= 0;
 
   /**
    * Creates a new input from a given argument
@@ -33,6 +33,16 @@ abstract class Input implements \lang\Value {
    */
   public function currentLine() {
     return $this->line;
+  }
+
+  /**
+   * Sets indent
+   *
+   * @param  int $delta
+   * @return void
+   */
+  public function indent($delta) {
+    $this->indent+= $delta;
   }
 
   /**
@@ -74,7 +84,8 @@ abstract class Input implements \lang\Value {
       if (!$this->hasMoreLines()) return null;
     }
     $this->line++;
-    return array_pop($this->stack);
+    $line= array_pop($this->stack);
+    return $this->indent ? substr($line, $this->indent) : $line;
   }
 
   /**

--- a/src/main/php/net/daringfireball/markdown/ListContext.class.php
+++ b/src/main/php/net/daringfireball/markdown/ListContext.class.php
@@ -55,11 +55,11 @@ class ListContext extends Context {
           $line->forward(strlen($m[0]));
           $this->tokenize($line, $target);
         }
-      } else if ('  ' === substr($line, 0, 2)) {
+      } else if ($space= strspn($line, ' ')) {
         $target= $result->last();
-        $indented= new Line(substr($line, 2));
+        $indented= new Line(substr($line, $space));
         $handled= false;
-        $lines->indent(+2);
+        $lines->indent(+$space);
 
         // Check handlers
         foreach ($this->handlers as $pattern => $handler) {
@@ -68,7 +68,7 @@ class ListContext extends Context {
           }
         }
 
-        $lines->indent(-2);
+        $lines->indent(-$space);
         $handled || $this->tokenize($indented, $target->add(new Paragraph()));
       } else {
         $lines->resetLine($line);

--- a/src/main/php/net/daringfireball/markdown/ListContext.class.php
+++ b/src/main/php/net/daringfireball/markdown/ListContext.class.php
@@ -56,11 +56,20 @@ class ListContext extends Context {
           $this->tokenize($line, $target);
         }
       } else if ('  ' === substr($line, 0, 2)) {
+        $target= $result->last();
+        $indented= new Line(substr($line, 2));
+        $handled= false;
+        $lines->indent(+2);
 
-        // Add paragraph to existing list item
-        $paragraph= $result->last()->add(new Paragraph());
-        $line->forward(2);
-        $this->tokenize($line, $paragraph);
+        // Check handlers
+        foreach ($this->handlers as $pattern => $handler) {
+          if (preg_match($pattern, $indented, $values)) {
+            if ($handled= $handler($lines, [$indented] + $values, $target, $this)) break;
+          }
+        }
+
+        $lines->indent(-2);
+        $handled || $this->tokenize($indented, $target->add(new Paragraph()));
       } else {
         $lines->resetLine($line);
         break;

--- a/src/main/php/net/daringfireball/markdown/Markdown.class.php
+++ b/src/main/php/net/daringfireball/markdown/Markdown.class.php
@@ -183,7 +183,7 @@ class Markdown {
     });
     $this->addHandler('/^\> /', function($lines, $matches, $result, $ctx) {
       $lines->resetLine($matches[0]);
-      $result->append($ctx->enter(new BlockquoteContext($ctx->handlers))->parse($lines));
+      $result->append($ctx->enter(new BlockquoteContext())->parse($lines));
       return true;
     });
     $this->addHandler('/^(    |\t)/', function($lines, $matches, $result, $ctx) {

--- a/src/main/php/net/daringfireball/markdown/NodeList.class.php
+++ b/src/main/php/net/daringfireball/markdown/NodeList.class.php
@@ -90,6 +90,16 @@ class NodeList extends Node {
   }
 
   /**
+   * Gets a slice of the node nodes
+   *
+   * @param  int $offset
+   * @return net.daringfireball.markdown.Node[]
+   */
+  public function slice($offset) {
+    return array_slice($this->nodes, $offset);
+  }
+
+  /**
    * Removes a node at a given position
    *
    * @param  int $pos

--- a/src/main/php/net/daringfireball/markdown/ToHtml.class.php
+++ b/src/main/php/net/daringfireball/markdown/ToHtml.class.php
@@ -290,6 +290,14 @@ class ToHtml implements Emitter {
    * @return string
    */
   public function emitListItem($item, $definitions) {
-    return '<li>'.$this->emitAll($item->list->paragraphs ? $item->all() : $item->get(0)->all(), $definitions).'</li>';
+    if ($item->list->paragraphs) return '<li>'.$this->emitAll($item->all(), $definitions).'</li>';  
+
+    // First element outside of paragraph, emit rest
+    return
+      '<li>'.
+      $this->emitAll($item->get(0)->all(), $definitions).
+      $this->emitAll($item->slice(1), $definitions).
+      '</li>'
+    ;
   }
 }

--- a/src/main/php/net/daringfireball/markdown/ToplevelContext.class.php
+++ b/src/main/php/net/daringfireball/markdown/ToplevelContext.class.php
@@ -1,22 +1,6 @@
 <?php namespace net\daringfireball\markdown;
 
 class ToplevelContext extends Context {
-  public $handlers= [];
-
-  /** @deprecated - Use withHandlers() instead! */
-  public function setHandlers($handlers) { $this->withHandlers($handlers); }
-
-  /**
-   * Sets handlers
-   * 
-   * @param  [:var] $handlers
-   * @return self
-   * @see    xp://net.daringfireball.markdown.Markdown#addHandler
-   */
-  public function withHandlers($handlers) {
-    $this->handlers= $handlers;
-    return $this;
-  }
 
   /**
    * Parse input into nodes

--- a/src/test/php/net/daringfireball/markdown/unittest/CodeTest.class.php
+++ b/src/test/php/net/daringfireball/markdown/unittest/CodeTest.class.php
@@ -159,6 +159,16 @@ class CodeTest extends MarkdownTest {
   }
 
   #[Test]
+  public function as_part_of_list_paragraphs() {
+    $this->assertTransformed(
+      "<ol>".
+        "<li>PHP:<pre><code>echo 'Hello';\n</code></pre><p>This will output Hello</p></li>".
+      "</ol>",
+      "1. PHP:\n\n   ```\n   echo 'Hello';\n   ```\n\n   This will output Hello\n"
+    );
+  }
+
+  #[Test]
   public function string_representation() {
     Assert::equals(
       'net.daringfireball.markdown.Code<1 + 2>',

--- a/src/test/php/net/daringfireball/markdown/unittest/CodeTest.class.php
+++ b/src/test/php/net/daringfireball/markdown/unittest/CodeTest.class.php
@@ -148,6 +148,17 @@ class CodeTest extends MarkdownTest {
   }
 
   #[Test]
+  public function as_part_of_list() {
+    $this->assertTransformed(
+      "<ul>".
+        "<li>PHP:<pre><code>echo 'Hello';\n</code></pre></li>".
+        "<li>JS:<pre><code>console.log('Hello')\n</code></pre></li>".
+      "</ul>",
+      "* PHP:\n  ```\n  echo 'Hello';\n  ```\n* JS:\n  ```\n  console.log('Hello')\n  ```"
+    );
+  }
+
+  #[Test]
   public function string_representation() {
     Assert::equals(
       'net.daringfireball.markdown.Code<1 + 2>',

--- a/src/test/php/net/daringfireball/markdown/unittest/ListsTest.class.php
+++ b/src/test/php/net/daringfireball/markdown/unittest/ListsTest.class.php
@@ -123,4 +123,12 @@ class ListsTest extends MarkdownTest {
       "* * *"
     );
   }
+
+  #[Test]
+  public function header_in_list() {
+    $this->assertTransformed(
+      "<ul><li>PHP:<h2>New</h2></li></ul>",
+      "* PHP:\n  ## New\n"
+    );
+  }
 }


### PR DESCRIPTION
## Example

~~~markdown
* PHP:
  ```
  echo 'Hello';
  ```
* JS:
  ```
  console.log('Hello')
  ```
~~~

This did not yield a list item containing a code block; instead, the additional lines were yielded as-is:

![image](https://user-images.githubusercontent.com/696742/228946509-fe2f7a36-8e50-48c9-b35b-0b3850633e83.png)
