### PR TITLE
Add support for line breaks

### DIFF
--- a/src/main/php/net/daringfireball/markdown/Context.class.php
+++ b/src/main/php/net/daringfireball/markdown/Context.class.php
@@ -88,6 +88,14 @@ abstract class Context implements Value {
 
       if ($safe++ > $l) throw new \lang\IllegalStateException('Endless loop detected');
     }
+
+    // If the string ends with two or more spaces, we have a manual line break.
+    // https://markdown-guide.readthedocs.io/en/latest/basics.html#line-return
+    if (0 === substr_compare($line, '  ', -2, 2)) {
+      if (($last= $target->last()) instanceof Text) $last->value= rtrim($last->value, ' ');
+      $target->add(new LineBreak());
+    }
+
     return $target;
   }
 

--- a/src/main/php/net/daringfireball/markdown/Context.class.php
+++ b/src/main/php/net/daringfireball/markdown/Context.class.php
@@ -91,7 +91,7 @@ abstract class Context implements Value {
 
     // If the string ends with two or more spaces, we have a manual line break.
     // https://markdown-guide.readthedocs.io/en/latest/basics.html#line-return
-    if (0 === substr_compare($line, '  ', -2, 2)) {
+    if ($l >= 2 && 0 === substr_compare($line, '  ', -2, 2)) {
       if (($last= $target->last()) instanceof Text) $last->value= rtrim($last->value, ' ');
       $target->add(new LineBreak());
     }

--- a/src/main/php/net/daringfireball/markdown/Emitter.class.php
+++ b/src/main/php/net/daringfireball/markdown/Emitter.class.php
@@ -1,6 +1,6 @@
 <?php namespace net\daringfireball\markdown;
 
-interface Emitter {
+abstract class Emitter {
 
   /**
    * Emits a parse tree
@@ -9,7 +9,7 @@ interface Emitter {
    * @param  [:net.daringfireball.markdown.Link] $definitions
    * @return string
    */
-  public function emitParseTree($tree, $definitions);
+  public function emitParseTree($tree, $definitions) { }
 
   /**
    * Emits a node list
@@ -18,7 +18,7 @@ interface Emitter {
    * @param  [:net.daringfireball.markdown.Link] $definitions
    * @return string
    */
-  public function emitNodeList($list, $definitions);
+  public function emitNodeList($list, $definitions) { }
 
   /**
    * Emits a header
@@ -27,7 +27,7 @@ interface Emitter {
    * @param  [:net.daringfireball.markdown.Link] $definitions
    * @return string
    */
-  public function emitHeader($header, $definitions);
+  public function emitHeader($header, $definitions) { }
 
   /**
    * Emits a paragraph
@@ -36,7 +36,7 @@ interface Emitter {
    * @param  [:net.daringfireball.markdown.Link] $definitions
    * @return string
    */
-  public function emitParagraph($paragraph, $definitions);
+  public function emitParagraph($paragraph, $definitions) { }
 
   /**
    * Emits a blockquote
@@ -45,7 +45,7 @@ interface Emitter {
    * @param  [:net.daringfireball.markdown.Link] $definitions
    * @return string
    */
-  public function emitBlockQuote($blockquote, $definitions);
+  public function emitBlockQuote($blockquote, $definitions) { }
 
   /**
    * Emits a ruler
@@ -54,7 +54,7 @@ interface Emitter {
    * @param  [:net.daringfireball.markdown.Link] $definitions
    * @return string
    */
-  public function emitRuler($ruler, $definitions);
+  public function emitRuler($ruler, $definitions) { }
 
   /**
    * Emits strike-through text
@@ -63,7 +63,7 @@ interface Emitter {
    * @param  [:net.daringfireball.markdown.Link] $definitions
    * @return string
    */
-  public function emitStrikeThrough($node, $definitions);
+  public function emitStrikeThrough($node, $definitions) { }
 
   /**
    * Emits italic text
@@ -72,7 +72,7 @@ interface Emitter {
    * @param  [:net.daringfireball.markdown.Link] $definitions
    * @return string
    */
-  public function emitItalic($node, $definitions);
+  public function emitItalic($node, $definitions) { }
 
   /**
    * Emits bold text
@@ -81,7 +81,7 @@ interface Emitter {
    * @param  [:net.daringfireball.markdown.Link] $definitions
    * @return string
    */
-  public function emitBold($node, $definitions);
+  public function emitBold($node, $definitions) { }
 
   /**
    * Emits a table
@@ -90,7 +90,7 @@ interface Emitter {
    * @param  [:net.daringfireball.markdown.Link] $definitions
    * @return string
    */
-  public function emitTable($table, $definitions);
+  public function emitTable($table, $definitions) { }
 
   /**
    * Emits a table row
@@ -99,7 +99,7 @@ interface Emitter {
    * @param  [:net.daringfireball.markdown.Link] $definitions
    * @return string
    */
-  public function emitRow($row, $definitions);
+  public function emitRow($row, $definitions) { }
 
   /**
    * Emits a table cell
@@ -108,7 +108,7 @@ interface Emitter {
    * @param  [:net.daringfireball.markdown.Link] $definitions
    * @return string
    */
-  public function emitCell($cell, $definitions);
+  public function emitCell($cell, $definitions) { }
 
   /**
    * Emits a text fragment
@@ -117,7 +117,7 @@ interface Emitter {
    * @param  [:net.daringfireball.markdown.Link] $definitions
    * @return string
    */
-  public function emitText($text, $definitions);
+  public function emitText($text, $definitions) { }
 
   /**
    * Emits a link
@@ -126,7 +126,7 @@ interface Emitter {
    * @param  [:net.daringfireball.markdown.Link] $definitions
    * @return string
    */
-  public function emitLink($link, $definitions);
+  public function emitLink($link, $definitions) { }
 
   /**
    * Emits an image
@@ -135,7 +135,7 @@ interface Emitter {
    * @param  [:net.daringfireball.markdown.Link] $definitions
    * @return string
    */
-  public function emitImage($image, $definitions);
+  public function emitImage($image, $definitions) { }
 
   /**
    * Emits an email address
@@ -144,7 +144,7 @@ interface Emitter {
    * @param  [:net.daringfireball.markdown.Link] $definitions
    * @return string
    */
-  public function emitEmail($email, $definitions);
+  public function emitEmail($email, $definitions) { }
 
   /**
    * Emits an entity
@@ -153,7 +153,7 @@ interface Emitter {
    * @param  [:net.daringfireball.markdown.Link] $definitions
    * @return string
    */
-  public function emitEntity($entity, $definitions);
+  public function emitEntity($entity, $definitions) { }
 
   /**
    * Emits a line break
@@ -162,7 +162,7 @@ interface Emitter {
    * @param  [:net.daringfireball.markdown.Link] $definitions
    * @return string
    */
-  public function emitLineBreak($br, $definitions);
+  public function emitLineBreak($br, $definitions) { }
 
   /**
    * Emits an inline code fragment
@@ -171,7 +171,7 @@ interface Emitter {
    * @param  [:net.daringfireball.markdown.Link] $definitions
    * @return string
    */
-  public function emitCode($code, $definitions);
+  public function emitCode($code, $definitions) { }
 
   /**
    * Emits a code block
@@ -180,7 +180,7 @@ interface Emitter {
    * @param  [:net.daringfireball.markdown.Link] $definitions
    * @return string
    */
-  public function emitCodeBlock($block, $definitions);
+  public function emitCodeBlock($block, $definitions) { }
 
   /**
    * Emits a listing (ordered or unordered)
@@ -189,7 +189,7 @@ interface Emitter {
    * @param  [:net.daringfireball.markdown.Link] $definitions
    * @return string
    */
-  public function emitListing($listing, $definitions);
+  public function emitListing($listing, $definitions) { }
 
   /**
    * Emits a list item
@@ -198,5 +198,5 @@ interface Emitter {
    * @param  [:net.daringfireball.markdown.Link] $definitions
    * @return string
    */
-  public function emitListItem($item, $definitions);
+  public function emitListItem($item, $definitions) { }
 }

--- a/src/main/php/net/daringfireball/markdown/Emitter.class.php
+++ b/src/main/php/net/daringfireball/markdown/Emitter.class.php
@@ -156,6 +156,15 @@ interface Emitter {
   public function emitEntity($entity, $definitions);
 
   /**
+   * Emits a line break
+   *
+   * @param  net.daringfireball.markdown.LineBreak $br
+   * @param  [:net.daringfireball.markdown.Link] $definitions
+   * @return string
+   */
+  public function emitLineBreak($br, $definitions);
+
+  /**
    * Emits an inline code fragment
    *
    * @param  net.daringfireball.markdown.Code $code

--- a/src/main/php/net/daringfireball/markdown/LineBreak.class.php
+++ b/src/main/php/net/daringfireball/markdown/LineBreak.class.php
@@ -1,0 +1,15 @@
+<?php namespace net\daringfireball\markdown;
+
+class LineBreak extends ValueNode {
+
+  /**
+   * Emit this node
+   *
+   * @param  net.daringfireball.markdown.Emitter $emitter
+   * @param  [:net.daringfireball.markdown.Link] $definitions
+   * @return string
+   */
+  public function emit($emitter, $definitions= []) {
+    return $emitter->emitLineBreak($this, $definitions);
+  }
+}

--- a/src/main/php/net/daringfireball/markdown/Markdown.class.php
+++ b/src/main/php/net/daringfireball/markdown/Markdown.class.php
@@ -44,15 +44,20 @@ class Markdown {
       return true;
     });
     $this->addToken('<', function($line, $target, $ctx) {
-      if (preg_match('#<(([a-z]+://)[^ >]+)>#', $line, $m, 0, $line->pos())) {
+      if ($line->matches('<br>')) {
+        $target->add(new LineBreak());
+        $line->forward(+4);
+        return true;
+      } else if (preg_match('#<(([a-z]+://)[^ >]+)>#', $line, $m, 0, $line->pos())) {
         $target->add(new Link($m[1]));
+        $line->forward(strlen($m[0]));
+        return true;
       } else if (preg_match('#<(([^ @]+)@[^ >]+)>#', $line, $m, 0, $line->pos())) {
         $target->add(new Email($m[1]));
-      } else {
-        return false;
+        $line->forward(strlen($m[0]));
+        return true;
       }
-      $line->forward(strlen($m[0]));
-      return true;
+      return false;
     });
 
     // *Word* => Emphasis, **Word** => Strong emphasis. Can nest other elements!

--- a/src/main/php/net/daringfireball/markdown/ToHtml.class.php
+++ b/src/main/php/net/daringfireball/markdown/ToHtml.class.php
@@ -97,7 +97,7 @@ class ToHtml extends Emitter {
    * @return string
    */
   public function emitRuler($ruler, $definitions) {
-    return '<hr />';
+    return '<hr>';
   }
 
   /**

--- a/src/main/php/net/daringfireball/markdown/ToHtml.class.php
+++ b/src/main/php/net/daringfireball/markdown/ToHtml.class.php
@@ -175,17 +175,7 @@ class ToHtml implements Emitter {
    * @return string
    */
   public function emitText($text, $definitions) {
-
-    // If the string ends with two or more spaces, we have a manual line break.
-    $sp= 0;
-    for ($i= strlen($text->value)- 1; $i > 0 && ' ' === $text->value[$i]; $i--) {
-      $sp++;
-    }
-    if ($sp >= 2) {
-      return htmlspecialchars(substr($text->value, 0, -$sp), $this->flags).'<br />';
-    } else {
-      return htmlspecialchars($text->value, $this->flags);
-    }
+    return htmlspecialchars($text->value, $this->flags);
   }
 
   /**

--- a/src/main/php/net/daringfireball/markdown/ToHtml.class.php
+++ b/src/main/php/net/daringfireball/markdown/ToHtml.class.php
@@ -3,9 +3,9 @@
 /**
  * Emits markdown as HTML
  *
- * @test xp://net.daringfireball.markdown.unittest.ToHtmlTest
+ * @test net.daringfireball.markdown.unittest.ToHtmlTest
  */
-class ToHtml implements Emitter {
+class ToHtml extends Emitter {
   protected $urls, $flags;
 
   /**

--- a/src/main/php/net/daringfireball/markdown/ToHtml.class.php
+++ b/src/main/php/net/daringfireball/markdown/ToHtml.class.php
@@ -244,6 +244,17 @@ class ToHtml implements Emitter {
   }
 
   /**
+   * Emits a line break
+   *
+   * @param  net.daringfireball.markdown.LineBreak $br
+   * @param  [:net.daringfireball.markdown.Link] $definitions
+   * @return string
+   */
+  public function emitLineBreak($br, $definitions) {
+    return '<br>';
+  }
+
+  /**
    * Emits an inline code fragment
    *
    * @param  net.daringfireball.markdown.Code $code

--- a/src/test/php/net/daringfireball/markdown/unittest/ListsTest.class.php
+++ b/src/test/php/net/daringfireball/markdown/unittest/ListsTest.class.php
@@ -115,7 +115,7 @@ class ListsTest extends MarkdownTest {
         "<li>Two</li>".
         "<li>Three</li>".
       "</ul>".
-      "<hr />",
+      "<hr>",
       "* One\n".
       "* Two\n".
       "* Three\n".

--- a/src/test/php/net/daringfireball/markdown/unittest/ParagraphTest.class.php
+++ b/src/test/php/net/daringfireball/markdown/unittest/ParagraphTest.class.php
@@ -26,7 +26,12 @@ class ParagraphTest extends MarkdownTest {
   }
 
   #[Test, Values(['  ', '   '])]
+  public function manual_line_break_with_two_or_more_spaces_after_text($sp) {
+    $this->assertTransformed('<p>Hello<br></p>', 'Hello'.$sp);
+  }
+
+  #[Test, Values(['  ', '   '])]
   public function manual_line_break_with_two_or_more_spaces($sp) {
-    $this->assertTransformed('<p>Hello<br /></p>', 'Hello'.$sp);
+    $this->assertTransformed('<p><br></p>', $sp);
   }
 }

--- a/src/test/php/net/daringfireball/markdown/unittest/RulerTest.class.php
+++ b/src/test/php/net/daringfireball/markdown/unittest/RulerTest.class.php
@@ -8,7 +8,7 @@ class RulerTest extends MarkdownTest {
 
   #[Test, Values(['* * *', '***', '*****'])]
   public function with_asterisks($input) {
-    $this->assertTransformed('<hr />', $input);
+    $this->assertTransformed('<hr>', $input);
   }
 
   #[Test]

--- a/src/test/php/net/daringfireball/markdown/unittest/TableTest.class.php
+++ b/src/test/php/net/daringfireball/markdown/unittest/TableTest.class.php
@@ -184,4 +184,17 @@ class TableTest extends MarkdownTest {
   public function issue_12($input) {
     $this->assertTransformed('<p>'.$input.'</p>', $input);
   }
+
+  #[Test]
+  public function line_breaks_in_table() {
+    $this->assertTransformed(
+      '<table>'.
+      '<tr><th>PHP</th><th>JS</th></tr>'.
+      '<tr><td>Server</td><td>Client<br>Server</td></tr>'.
+      '</table>',
+      "PHP     | JS\n".
+      "------- | -----\n".
+      "Server  | Client<br>Server\n"
+    );
+  }
 }

--- a/src/test/php/net/daringfireball/markdown/unittest/ToHtmlTest.class.php
+++ b/src/test/php/net/daringfireball/markdown/unittest/ToHtmlTest.class.php
@@ -27,11 +27,6 @@ class ToHtmlTest {
     Assert::equals('Test ', (new Text('Test '))->emit(new ToHtml()));
   }
 
-  #[Test, Values(['  ', '   '])]
-  public function manual_line_break_with_two_or_more_spaces($spaces) {
-    Assert::equals('Test<br />', (new Text('Test'.$spaces))->emit(new ToHtml()));
-  }
-
   #[Test]
   public function emails_are_encoded() {
     $encoded= '&#x74;&#x69;&#x6d;&#x6d;&#x40;&#x65;&#x78;&#x61;&#x6d;&#x70;&#x6c;&#x65;&#x2e;&#x63;&#x6f;&#x6d;';


### PR DESCRIPTION
This pull request adds support for explicit line breaks.

* [x] Via `<br>`
* [x] Via two empty spaces at the end of a line (see https://markdown-guide.readthedocs.io/en/latest/basics.html#line-return)

⚠️ This PR breaks BC by changing the `Emitter` interface to an abstract base class with empty implementations. The alternative was to break BC by adding a new interface method... with this change, we'll remove this kind of BC break in the future.